### PR TITLE
Add borderless styleType to DropdownButton

### DIFF
--- a/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
@@ -10,7 +10,7 @@ import { MenuItem } from '../../Menu';
 import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
 import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
 
-function renderComponent(...props: Partial<DropdownButtonProps>[]) {
+function renderComponent(props?: Partial<DropdownButtonProps>) {
   return render(
     <DropdownButton
       menuItems={(close) => [
@@ -82,4 +82,9 @@ it('should work with menu items', () => {
 
   tippy = document.querySelector('[data-tippy-root]') as HTMLElement;
   expect(tippy.style.visibility).toEqual('hidden');
+});
+
+it('should render borderless button correctly', () => {
+  const { container } = renderComponent({ styleType: 'borderless' });
+  expect(container.querySelector('.iui-button.iui-borderless')).toBeTruthy();
 });

--- a/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -19,7 +19,13 @@ export type DropdownButtonProps = {
    * and returns a list of `MenuItem` components.
    */
   menuItems: (close: () => void) => JSX.Element[];
-} & Omit<ButtonProps, 'onClick' | 'styleType' | 'endIcon'>;
+  /**
+   * Style of the dropdown.
+   * Use 'borderless' to hide outline.
+   * @default 'default'
+   */
+  styleType?: 'default' | 'borderless';
+} & Omit<ButtonProps, 'onClick' | 'endIcon'>;
 
 /**
  * Button that opens a DropdownMenu.

--- a/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -25,7 +25,7 @@ export type DropdownButtonProps = {
    * @default 'default'
    */
   styleType?: 'default' | 'borderless';
-} & Omit<ButtonProps, 'onClick' | 'endIcon'>;
+} & Omit<ButtonProps, 'onClick' | 'styleType' | 'endIcon'>;
 
 /**
  * Button that opens a DropdownMenu.
@@ -37,7 +37,7 @@ export type DropdownButtonProps = {
  * <DropdownButton menuItems={menuItems}>Default</DropdownButton>
  */
 export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
-  const { menuItems, className, size, children, ...rest } = props;
+  const { menuItems, className, size, styleType, children, ...rest } = props;
 
   useTheme();
 
@@ -50,7 +50,7 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
     if (ref.current) {
       setMenuWidth(ref.current.offsetWidth);
     }
-  }, [children, size]);
+  }, [children, size, styleType]);
 
   return (
     <DropdownMenu
@@ -62,6 +62,7 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
       <Button
         className={cx('iui-dropdown', className)}
         size={size}
+        styleType={styleType}
         endIcon={isMenuOpen ? <SvgCaretUpSmall /> : <SvgCaretDownSmall />}
         ref={ref}
         {...rest}

--- a/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -20,7 +20,7 @@ export type DropdownButtonProps = {
    */
   menuItems: (close: () => void) => JSX.Element[];
   /**
-   * Style of the dropdown.
+   * Style of the dropdown button.
    * Use 'borderless' to hide outline.
    * @default 'default'
    */

--- a/src/core/Buttons/SplitButton/SplitButton.test.tsx
+++ b/src/core/Buttons/SplitButton/SplitButton.test.tsx
@@ -12,7 +12,7 @@ import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
 
 function renderComponent(
   onClick?: () => void,
-  ...props: Partial<SplitButtonProps>[]
+  props?: Partial<SplitButtonProps>,
 ) {
   return render(
     <SplitButton


### PR DESCRIPTION
Previously, we were omitting the `styleType` prop, but after discussion with @FlyersPh9 and @raplemie, it is a valid case to have a borderless dropdown, so I added it.

Also fixed an issue with partial props syntax in unit tests.