### PR TITLE
Disallow creating blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: Questions 🤔
     url: https://github.com/iTwin/iTwinUI-react/discussions/categories/q-a


### PR DESCRIPTION
Should make it harder for users to ignore our nice issue templates ([source](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)).