### PR TITLE
Add Popover props to Select

### DIFF
--- a/src/core/Select/Select.tsx
+++ b/src/core/Select/Select.tsx
@@ -88,6 +88,14 @@ export type SelectProps<T> = {
    * Custom style for menu.
    */
   menuStyle?: React.CSSProperties;
+  /**
+   * Props to customize Popover behavior.
+   * @see tippy.js {@link https://atomiks.github.io/tippyjs/v6/all-props/ props}
+   */
+  popoverProps?: Omit<
+    PopoverProps,
+    'onShow' | 'onHide' | 'visible' | 'disabled'
+  >;
 } & Pick<PopoverProps, 'onShow' | 'onHide'> &
   CommonProps;
 
@@ -156,6 +164,7 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
     menuStyle,
     onShow,
     onHide,
+    popoverProps,
     ...rest
   } = props;
 
@@ -255,6 +264,7 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
       onHide={onHideHandler}
       visible={isOpen}
       disabled={disabled}
+      {...popoverProps}
     >
       <div
         className={cx('iui-select', className)}

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -29,7 +29,8 @@ export type PopoverProps = {
 } & Omit<TippyProps, 'placement' | 'trigger' | 'visible'>;
 
 /**
- * Wrapper around Tippy with pre-configured props and plugins (e.g. lazy mounting, focus, etc).
+ * Wrapper around {@link https://atomiks.github.io/tippyjs tippy.js}
+ * with pre-configured props and plugins (e.g. lazy mounting, focus, etc).
  * @private
  */
 export const Popover = React.forwardRef((props: PopoverProps, ref) => {


### PR DESCRIPTION
Added `popoverProps` as a single prop destructured and passed down to `DropdownMenu`, with JSDoc comment linking back to tippy.js site.

This should give users more control over the popover behavior, allowing for things like appending `Select` to body. Some props are omitted because we have custom implementations for those.

Also added tippy.js link in `Popover` itself.