### PR TITLE
Fix tooltip blurred text by disabling gpu acceleration

### DIFF
--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -46,6 +46,14 @@ export const Tooltip = (props: TooltipProps) => {
       }
       offset={[0, 4]}
       ref={ref}
+      popperOptions={{
+        modifiers: [
+          {
+            name: 'computeStyles',
+            options: { gpuAcceleration: false },
+          },
+        ],
+      }}
       {...rest}
     >
       {React.cloneElement(children, { title: undefined })}

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -63,13 +63,14 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     arrow: false,
     duration: 0,
     interactive: true,
-    popperOptions: {
-      strategy: 'fixed',
-      modifiers: [{ name: 'flip' }],
-    },
     role: undefined,
     offset: [0, 0],
     ...props,
+    popperOptions: {
+      strategy: 'fixed',
+      modifiers: [{ name: 'flip' }],
+      ...props.popperOptions,
+    },
     plugins: [lazyLoad, removeTabIndex, hideOnEsc, ...(props.plugins || [])],
   };
 


### PR DESCRIPTION
3D transforms seem to cause issues with backdrop-filter.

Disabling [`gpuAcceleration`](https://popper.js.org/docs/v2/modifiers/compute-styles/#gpuacceleration) means the tooltip will use `inset` instead of `transform`.