### PR TITLE
Add FileUpload component with drag & drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [X.X.X]
+
+`2021-05-XX`
+
+### What's new
+
+- **Added new `FileUpload` component** with drag & drop functionality.
+
 ## [1.2.0]
 
 `2021-04-29`

--- a/src/core/FileUpload/FileUpload.test.tsx
+++ b/src/core/FileUpload/FileUpload.test.tsx
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { FileUpload } from './FileUpload';
 
-it('should render in its most basic state', () => {
+it('should render content and children', () => {
   const mockContent = 'Mock drag content';
   const mockChildren = 'Mock children to wrap';
   const { container } = render(
@@ -26,4 +26,31 @@ it('should render in its most basic state', () => {
   const children = component.lastChild as HTMLElement;
   expect(children).toBeTruthy();
   expect(children.textContent).toEqual(mockChildren);
+});
+
+it('should handle drag and drop events correctly', () => {
+  const mockFn = jest.fn();
+  const { container } = render(
+    <FileUpload content={'Mock content'} onFileDropped={mockFn} />,
+  );
+
+  const component = container.querySelector('.iui-file-upload') as HTMLElement;
+  expect(component).toBeTruthy();
+
+  expect(container.querySelector('.iui-content')).toBeTruthy();
+
+  const file = new File(['mock-file'], 'test.txt', { type: 'text/plain' });
+  const mockDataTransfer = {
+    dataTransfer: { files: [file], items: [{ kind: 'file', type: file.type }] },
+  };
+
+  fireEvent.dragOver(component, mockDataTransfer);
+  expect(container.querySelector('.iui-file-upload.iui-drag')).toBeTruthy();
+
+  fireEvent.dragLeave(component, mockDataTransfer);
+  expect(container.querySelector('.iui-file-upload.iui-drag')).toBeFalsy();
+
+  fireEvent.dragOver(component, mockDataTransfer);
+  fireEvent.drop(component, mockDataTransfer);
+  expect(mockFn).toHaveBeenCalledWith([file]);
 });

--- a/src/core/FileUpload/FileUpload.test.tsx
+++ b/src/core/FileUpload/FileUpload.test.tsx
@@ -23,7 +23,7 @@ it('should render dragContent and children', () => {
   expect(content).toBeTruthy();
   expect(content.textContent).toEqual(mockContent);
 
-  const children = component.lastChild as HTMLElement;
+  const children = component.firstChild as HTMLElement;
   expect(children).toBeTruthy();
   expect(children.textContent).toEqual(mockChildren);
 });

--- a/src/core/FileUpload/FileUpload.test.tsx
+++ b/src/core/FileUpload/FileUpload.test.tsx
@@ -8,13 +8,22 @@ import { render } from '@testing-library/react';
 import { FileUpload } from './FileUpload';
 
 it('should render in its most basic state', () => {
-  // TODO: Make sure all required props are passed in here
-  const { container } = render(<FileUpload />);
-  expect(container.querySelector('div')).toBeTruthy();
-});
+  const mockContent = 'Mock drag content';
+  const mockChildren = 'Mock children to wrap';
+  const { container } = render(
+    <FileUpload content={mockContent} onFileDropped={jest.fn}>
+      {mockChildren}
+    </FileUpload>,
+  );
 
-// TODO: Write tests here!
+  const component = container.querySelector('.iui-file-upload') as HTMLElement;
+  expect(component).toBeTruthy();
 
-it('should be improved', () => {
-  expect(false).toBe(true);
+  const content = container.querySelector('.iui-content') as HTMLElement;
+  expect(content).toBeTruthy();
+  expect(content.textContent).toEqual(mockContent);
+
+  const children = component.lastChild as HTMLElement;
+  expect(children).toBeTruthy();
+  expect(children.textContent).toEqual(mockChildren);
 });

--- a/src/core/FileUpload/FileUpload.test.tsx
+++ b/src/core/FileUpload/FileUpload.test.tsx
@@ -7,11 +7,11 @@ import { fireEvent, render } from '@testing-library/react';
 
 import { FileUpload } from './FileUpload';
 
-it('should render content and children', () => {
+it('should render dragContent and children', () => {
   const mockContent = 'Mock drag content';
   const mockChildren = 'Mock children to wrap';
   const { container } = render(
-    <FileUpload content={mockContent} onFileDropped={jest.fn}>
+    <FileUpload dragContent={mockContent} onFileDropped={jest.fn}>
       {mockChildren}
     </FileUpload>,
   );
@@ -28,10 +28,22 @@ it('should render content and children', () => {
   expect(children.textContent).toEqual(mockChildren);
 });
 
+it('should apply content class to children if dragContent not passed', () => {
+  const mockChildren = 'Mock children to wrap';
+  const { container } = render(
+    <FileUpload onFileDropped={jest.fn}>{mockChildren}</FileUpload>,
+  );
+  expect(container.querySelector('.iui-file-upload')).toBeTruthy();
+
+  const content = container.querySelector('.iui-content') as HTMLElement;
+  expect(content).toBeTruthy();
+  expect(content.textContent).toEqual(mockChildren);
+});
+
 it('should handle drag and drop events correctly', () => {
   const mockFn = jest.fn();
   const { container } = render(
-    <FileUpload content={'Mock content'} onFileDropped={mockFn} />,
+    <FileUpload onFileDropped={mockFn}>Mock content</FileUpload>,
   );
 
   const component = container.querySelector('.iui-file-upload') as HTMLElement;

--- a/src/core/FileUpload/FileUpload.test.tsx
+++ b/src/core/FileUpload/FileUpload.test.tsx
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { FileUpload } from './FileUpload';
+
+it('should render in its most basic state', () => {
+  // TODO: Make sure all required props are passed in here
+  const { container } = render(<FileUpload />);
+  expect(container.querySelector('div')).toBeTruthy();
+});
+
+// TODO: Write tests here!
+
+it('should be improved', () => {
+  expect(false).toBe(true);
+});

--- a/src/core/FileUpload/FileUpload.test.tsx
+++ b/src/core/FileUpload/FileUpload.test.tsx
@@ -44,13 +44,13 @@ it('should handle drag and drop events correctly', () => {
     dataTransfer: { files: [file], items: [{ kind: 'file', type: file.type }] },
   };
 
-  fireEvent.dragOver(component, mockDataTransfer);
+  fireEvent.dragEnter(component, mockDataTransfer);
   expect(container.querySelector('.iui-file-upload.iui-drag')).toBeTruthy();
 
   fireEvent.dragLeave(component, mockDataTransfer);
   expect(container.querySelector('.iui-file-upload.iui-drag')).toBeFalsy();
 
-  fireEvent.dragOver(component, mockDataTransfer);
+  fireEvent.dragEnter(component, mockDataTransfer);
   fireEvent.drop(component, mockDataTransfer);
   expect(mockFn).toHaveBeenCalledWith([file]);
 });

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -44,52 +44,43 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
     const fileUploadRef = React.useRef<HTMLDivElement>(null);
     const refs = useMergedRefs(fileUploadRef, ref);
 
-    const onDragEnterHandler = React.useCallback((e: React.DragEvent) => {
+    const onDragOverHandler = (e: React.DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
-    }, []);
+    };
 
-    const onDragOverHandler = React.useCallback(
-      (e: React.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
+    const onDragEnterHandler = (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
 
-        // only set active if a valid file is dragged over
-        if (!isDragActive && e.dataTransfer?.items?.[0]?.kind === 'file') {
-          setIsDragActive(true);
-        }
-      },
-      [isDragActive],
-    );
+      // only set active if a file is dragged over
+      if (!isDragActive && e.dataTransfer?.items?.[0]?.kind === 'file') {
+        setIsDragActive(true);
+      }
+    };
 
-    const onDragLeaveHandler = React.useCallback(
-      (e: React.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
+    const onDragLeaveHandler = (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
 
-        // only set inactive if secondary target is outside the component
-        if (
-          isDragActive &&
-          !fileUploadRef.current?.contains(e.relatedTarget as Node)
-        ) {
-          setIsDragActive(false);
-        }
-      },
-      [isDragActive],
-    );
+      // only set inactive if secondary target is outside the component
+      if (
+        isDragActive &&
+        !fileUploadRef.current?.contains(e.relatedTarget as Node)
+      ) {
+        setIsDragActive(false);
+      }
+    };
 
-    const onDropHandler = React.useCallback(
-      (e: React.DragEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
+    const onDropHandler = (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
 
-        if (isDragActive) {
-          setIsDragActive(false);
-        }
+      if (isDragActive) {
+        setIsDragActive(false);
         onFileDropped(e.dataTransfer?.files);
-      },
-      [isDragActive, onFileDropped],
-    );
+      }
+    };
 
     return (
       <div

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -95,8 +95,8 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         ref={refs}
         {...rest}
       >
-        {dragContent && <div className='iui-content'>{dragContent}</div>}
         {dragContent ? children : <div className='iui-content'>{children}</div>}
+        {dragContent && <div className='iui-content'>{dragContent}</div>}
       </div>
     );
   },

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -55,7 +55,7 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         e.stopPropagation();
 
         // only set active if a valid file is dragged over
-        if (!isDragActive && e.dataTransfer?.items?.[0]) {
+        if (!isDragActive && e.dataTransfer?.items?.[0]?.kind === 'file') {
           setIsDragActive(true);
         }
       },

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -11,7 +11,7 @@ import '@itwin/itwinui-css/css/file-upload.css';
 
 export type FileUploadProps = {
   /**
-   * Content shown when file is being dragged onto the component.
+   * Content shown over `children` when file is being dragged onto the component.
    */
   content: React.ReactNode;
   /**
@@ -26,10 +26,14 @@ export type FileUploadProps = {
 } & CommonProps;
 
 /**
- * File upload component to be used as a wrapper or standlone.
- * Provides support for dragging files.
+ * File upload component to be used as a wrapper or standalone.
+ * Provides support for dragging and dropping files.
  * @example
- * <FileUpload content={<span>Drop file to upload</span>}><Textarea /></FileUpload>
+ * <FileUpload content='Drop file here' onFileDropped={console.log}><Textarea /></FileUpload>
+ * <FileUpload
+ *   content={<><SvgUpload className='iui-icon' /> Upload file</>}
+ *   onFileDropped={console.log}
+ * />
  */
 export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
   (props, ref) => {
@@ -40,16 +44,17 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
     const fileUploadRef = React.useRef<HTMLDivElement>(null);
     const refs = useMergedRefs(fileUploadRef, ref);
 
-    const _onDragEnter = React.useCallback((e: React.DragEvent) => {
+    const onDragEnterHandler = React.useCallback((e: React.DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
     }, []);
 
-    const _onDragOver = React.useCallback(
+    const onDragOverHandler = React.useCallback(
       (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
 
+        // only set active if a valid file is dragged over
         if (!isDragActive && e.dataTransfer?.items?.[0]) {
           setIsDragActive(true);
         }
@@ -57,11 +62,12 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
       [isDragActive],
     );
 
-    const _onDragLeave = React.useCallback(
+    const onDragLeaveHandler = React.useCallback(
       (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
 
+        // only set inactive if secondary target is outside the component
         if (
           isDragActive &&
           !fileUploadRef.current?.contains(e.relatedTarget as Node)
@@ -72,7 +78,7 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
       [isDragActive],
     );
 
-    const _onDrop = React.useCallback(
+    const onDropHandler = React.useCallback(
       (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
@@ -92,10 +98,10 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
           { 'iui-drag': isDragActive },
           className,
         )}
-        onDragEnter={_onDragEnter}
-        onDragOver={_onDragOver}
-        onDragLeave={_onDragLeave}
-        onDrop={_onDrop}
+        onDragEnter={onDragEnterHandler}
+        onDragOver={onDragOverHandler}
+        onDragLeave={onDragLeaveHandler}
+        onDrop={onDropHandler}
         ref={refs}
         {...rest}
       >

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import cx from 'classnames';
 import { useTheme } from '../utils/hooks/useTheme';
 import { CommonProps } from '../utils/props';
+import { useMergedRefs } from '../utils/hooks/useMergedRefs';
 import '@itwin/itwinui-css/css/file-upload.css';
 
 export type FileUploadProps = {
@@ -36,7 +37,8 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
     useTheme();
 
     const [isDragActive, setIsDragActive] = React.useState(false);
-    const dragTargetRef = React.useRef<EventTarget>();
+    const fileUploadRef = React.useRef<HTMLDivElement>(null);
+    const refs = useMergedRefs(fileUploadRef, ref);
 
     const _onDragEnter = React.useCallback((e: React.DragEvent) => {
       e.preventDefault();
@@ -49,7 +51,6 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         e.stopPropagation();
 
         if (!isDragActive && e.dataTransfer?.items?.[0]) {
-          dragTargetRef.current = e.target;
           setIsDragActive(true);
         }
       },
@@ -61,8 +62,10 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         e.preventDefault();
         e.stopPropagation();
 
-        if (isDragActive && dragTargetRef.current !== e.target) {
-          dragTargetRef.current = undefined;
+        if (
+          isDragActive &&
+          !fileUploadRef.current?.contains(e.relatedTarget as Node)
+        ) {
           setIsDragActive(false);
         }
       },
@@ -77,8 +80,6 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         if (isDragActive) {
           setIsDragActive(false);
         }
-
-        dragTargetRef.current = undefined;
         onFileDropped(e.dataTransfer?.files?.[0]);
       },
       [isDragActive, onFileDropped],
@@ -95,7 +96,7 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         onDragOver={_onDragOver}
         onDragLeave={_onDragLeave}
         onDrop={_onDrop}
-        ref={ref}
+        ref={refs}
         {...rest}
       >
         <div className='iui-content'>{content}</div>

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -15,9 +15,9 @@ export type FileUploadProps = {
    */
   content: React.ReactNode;
   /**
-   * Callback fired when a file is dropped onto the component.
+   * Callback fired when files are dropped onto the component.
    */
-  onFileDropped: (file: File) => void;
+  onFileDropped: (files: FileList) => void;
   /**
    * Component to wrap `FileUpload` around.
    * `content` will be shown if `children` is not provided.
@@ -27,7 +27,7 @@ export type FileUploadProps = {
 
 /**
  * File upload component to be used as a wrapper or standalone.
- * Provides support for dragging and dropping files.
+ * Provides support for dragging and dropping multiple files.
  * @example
  * <FileUpload content='Drop file here' onFileDropped={console.log}><Textarea /></FileUpload>
  * <FileUpload
@@ -86,7 +86,7 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         if (isDragActive) {
           setIsDragActive(false);
         }
-        onFileDropped(e.dataTransfer?.files?.[0]);
+        onFileDropped(e.dataTransfer?.files);
       },
       [isDragActive, onFileDropped],
     );

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from 'react';
+import cx from 'classnames';
+import { useTheme } from '../utils/hooks/useTheme';
+import { CommonProps } from '../utils/props';
+import '@itwin/itwinui-css/css/file-upload.css';
+
+export type FileUploadProps = {
+  /**
+   * Content shown when file is being dragged onto the component.
+   */
+  content: React.ReactNode;
+  /**
+   * Callback fired when a file is dropped onto the component.
+   */
+  onFileDropped: (file: File) => void;
+  /**
+   * Component to wrap `FileUpload` around.
+   * `content` will be shown if `children` is not provided.
+   */
+  children?: React.ReactNode;
+} & CommonProps;
+
+/**
+ * File upload component to be used as a wrapper or standlone.
+ * Provides support for dragging files.
+ * @example
+ * <FileUpload content={<span>Drop file to upload</span>}><Textarea /></FileUpload>
+ */
+export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
+  (props, ref) => {
+    const { content, children, onFileDropped, className, ...rest } = props;
+    useTheme();
+
+    const [isDragActive, setIsDragActive] = React.useState(false);
+    const dragTargetRef = React.useRef<EventTarget>();
+
+    const _onDragEnter = React.useCallback((e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+    }, []);
+
+    const _onDragOver = React.useCallback(
+      (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (!isDragActive && e.dataTransfer?.items?.[0]) {
+          dragTargetRef.current = e.target;
+          setIsDragActive(true);
+        }
+      },
+      [isDragActive],
+    );
+
+    const _onDragLeave = React.useCallback(
+      (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (isDragActive && dragTargetRef.current !== e.target) {
+          dragTargetRef.current = undefined;
+          setIsDragActive(false);
+        }
+      },
+      [isDragActive],
+    );
+
+    const _onDrop = React.useCallback(
+      (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (isDragActive) {
+          setIsDragActive(false);
+        }
+
+        dragTargetRef.current = undefined;
+        onFileDropped(e.dataTransfer?.files?.[0]);
+      },
+      [isDragActive, onFileDropped],
+    );
+
+    return (
+      <div
+        className={cx(
+          'iui-file-upload',
+          { 'iui-drag': isDragActive },
+          className,
+        )}
+        onDragEnter={_onDragEnter}
+        onDragOver={_onDragOver}
+        onDragLeave={_onDragLeave}
+        onDrop={_onDrop}
+        ref={ref}
+        {...rest}
+      >
+        <div className='iui-content'>{content}</div>
+        {children}
+      </div>
+    );
+  },
+);
+
+export default FileUpload;

--- a/src/core/FileUpload/FileUpload.tsx
+++ b/src/core/FileUpload/FileUpload.tsx
@@ -12,32 +12,31 @@ import '@itwin/itwinui-css/css/file-upload.css';
 export type FileUploadProps = {
   /**
    * Content shown over `children` when file is being dragged onto the component.
+   * Should always be used when drag content differs from `children` being wrapped.
+   * Can be skipped if wrapping `FileUploadTemplate`.
    */
-  content: React.ReactNode;
+  dragContent?: React.ReactNode;
   /**
    * Callback fired when files are dropped onto the component.
    */
   onFileDropped: (files: FileList) => void;
   /**
    * Component to wrap `FileUpload` around.
-   * `content` will be shown if `children` is not provided.
+   * Either pass `FileUploadTemplate` (for default state) or a different component to wrap.
    */
-  children?: React.ReactNode;
+  children: React.ReactNode;
 } & CommonProps;
 
 /**
- * File upload component to be used as a wrapper or standalone.
+ * File upload component to be wrapped around `FileUploadTemplate` or any arbitrary component.
  * Provides support for dragging and dropping multiple files.
  * @example
- * <FileUpload content='Drop file here' onFileDropped={console.log}><Textarea /></FileUpload>
- * <FileUpload
- *   content={<><SvgUpload className='iui-icon' /> Upload file</>}
- *   onFileDropped={console.log}
- * />
+ * <FileUpload onFileDropped={console.log}><FileUploadTemplate /></FileUpload>
+ * <FileUpload dragContent='Drop file here' onFileDropped={console.log}><Textarea /></FileUpload>
  */
 export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
   (props, ref) => {
-    const { content, children, onFileDropped, className, ...rest } = props;
+    const { dragContent, children, onFileDropped, className, ...rest } = props;
     useTheme();
 
     const [isDragActive, setIsDragActive] = React.useState(false);
@@ -96,8 +95,8 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
         ref={refs}
         {...rest}
       >
-        <div className='iui-content'>{content}</div>
-        {children}
+        {dragContent && <div className='iui-content'>{dragContent}</div>}
+        {dragContent ? children : <div className='iui-content'>{children}</div>}
       </div>
     );
   },

--- a/src/core/FileUpload/FileUploadTemplate.test.tsx
+++ b/src/core/FileUpload/FileUploadTemplate.test.tsx
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { FileUploadTemplate } from './FileUploadTemplate';
+import SvgUpload from '@itwin/itwinui-icons-react/cjs/icons/Upload';
+
+it('should render FileUploadTemplate', () => {
+  const mockedOnChange = jest.fn();
+  const { container } = render(
+    <FileUploadTemplate onChange={mockedOnChange} />,
+  );
+
+  const input = container.querySelector(
+    '.iui-browse-input',
+  ) as HTMLInputElement;
+  expect(input).toBeTruthy();
+  fireEvent.change(input);
+  expect(mockedOnChange).toBeCalled();
+
+  const label = container.querySelector(
+    '.iui-template-text > .iui-anchor',
+  ) as HTMLElement;
+  expect(label).toBeTruthy();
+  expect(label.textContent).toEqual('Choose a file');
+
+  const secondary = container.querySelector(
+    '.iui-template-text > div',
+  ) as HTMLElement;
+  expect(secondary).toBeTruthy();
+  expect(secondary.textContent).toEqual('or drag & drop it here.');
+
+  const { container: uploadIcon } = render(
+    <SvgUpload aria-hidden className='iui-icon' />,
+  );
+  const svg = container.querySelector('.iui-icon') as SVGSVGElement;
+  expect(svg).toBeTruthy();
+  expect(svg).toEqual(uploadIcon.firstChild);
+});

--- a/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/src/core/FileUpload/FileUploadTemplate.tsx
@@ -43,7 +43,7 @@ export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
   const {
     onChange,
     acceptMultiple = true,
-    label = 'Choose a file.',
+    label = 'Choose a file',
     subtitle = 'or drag & drop it here.',
     children,
   } = props;

--- a/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/src/core/FileUpload/FileUploadTemplate.tsx
@@ -59,13 +59,13 @@ export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
         multiple={acceptMultiple}
       />
       <SvgUpload className='iui-icon' />
-      <div className='iui-label'>
+      <div className='iui-template-text'>
         <label htmlFor='file-input' className='iui-anchor'>
           {label}
         </label>
         <div>{subtitle}</div>
+        {children}
       </div>
-      {children}
     </>
   );
 };

--- a/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/src/core/FileUpload/FileUploadTemplate.tsx
@@ -13,12 +13,22 @@ export type FileUploadTemplateProps = {
    */
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   /**
-   * Localized version of primary label. First line gets styled like a hyperlink.
-   * @default 'Choose a file.\n Or drag & drop it here.'
+   * Whether the file input accepts multiple files.
+   * @default true
+   */
+  acceptMultiple?: boolean;
+  /**
+   * Localized version of primary clickable label. Gets styled like a hyperlink.
+   * @default 'Choose a file'
    */
   label?: React.ReactNode;
   /**
-   * Optional children appended to main label.
+   * Localized version of the secondary text shown below the label.
+   * @default 'or drag & drop it here.'
+   */
+  subtitle?: React.ReactNode;
+  /**
+   * Optional children appended to the template.
    */
   children?: React.ReactNode;
 };
@@ -30,7 +40,13 @@ export type FileUploadTemplateProps = {
  * <FileUploadTemplate onChange={(e) => console.log(e.target.files)} />
  */
 export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
-  const { onChange, label, children } = props;
+  const {
+    onChange,
+    acceptMultiple = true,
+    label = 'Choose a file.',
+    subtitle = 'or drag & drop it here.',
+    children,
+  } = props;
   useTheme();
 
   return (
@@ -40,18 +56,15 @@ export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
         type='file'
         id='file-input'
         onChange={onChange}
-        multiple
+        multiple={acceptMultiple}
       />
       <SvgUpload className='iui-icon' />
-      <label htmlFor='file-input' className='iui-anchor'>
-        {label ?? (
-          <>
-            {'Choose a file.'}
-            <br />
-            {'Or drag & drop it here.'}
-          </>
-        )}
-      </label>
+      <div className='iui-label'>
+        <label htmlFor='file-input' className='iui-anchor'>
+          {label}
+        </label>
+        <div>{subtitle}</div>
+      </div>
       {children}
     </>
   );

--- a/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/src/core/FileUpload/FileUploadTemplate.tsx
@@ -58,7 +58,7 @@ export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
         onChange={onChange}
         multiple={acceptMultiple}
       />
-      <SvgUpload className='iui-icon' />
+      <SvgUpload className='iui-icon' aria-hidden />
       <div className='iui-template-text'>
         <label htmlFor='file-input' className='iui-anchor'>
           {label}

--- a/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/src/core/FileUpload/FileUploadTemplate.tsx
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from 'react';
+import { useTheme } from '../utils/hooks/useTheme';
+import '@itwin/itwinui-css/css/file-upload.css';
+import SvgUpload from '@itwin/itwinui-icons-react/cjs/icons/Upload';
+
+export type FileUploadTemplateProps = {
+  /**
+   * Callback fired when a file is selected from the device.
+   */
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Localized version of primary label. First line gets styled like a hyperlink.
+   * @default 'Choose a file.\n Or drag & drop it here.'
+   */
+  label?: React.ReactNode;
+  /**
+   * Optional children appended to main label.
+   */
+  children?: React.ReactNode;
+};
+
+/**
+ * Default template to be used with the `FileUpload` wrapper component.
+ * Contains a hidden input with styled labels (customizable).
+ * @example
+ * <FileUploadTemplate onChange={(e) => console.log(e.target.files)} />
+ */
+export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
+  const { onChange, label, children } = props;
+  useTheme();
+
+  return (
+    <>
+      <input
+        className='iui-browse-input'
+        type='file'
+        id='file-input'
+        onChange={onChange}
+        multiple
+      />
+      <SvgUpload className='iui-icon' />
+      <label htmlFor='file-input' className='iui-anchor'>
+        {label ?? (
+          <>
+            {'Choose a file.'}
+            <br />
+            {'Or drag & drop it here.'}
+          </>
+        )}
+      </label>
+      {children}
+    </>
+  );
+};
+
+export default FileUploadTemplate;

--- a/src/core/FileUpload/index.ts
+++ b/src/core/FileUpload/index.ts
@@ -5,3 +5,6 @@
 export { FileUpload } from './FileUpload';
 export type { FileUploadProps } from './FileUpload';
 export default './FileUpload';
+
+export { FileUploadTemplate } from './FileUploadTemplate';
+export type { FileUploadTemplateProps } from './FileUploadTemplate';

--- a/src/core/FileUpload/index.ts
+++ b/src/core/FileUpload/index.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+export { FileUpload } from './FileUpload';
+export type { FileUploadProps } from './FileUpload';
+export default './FileUpload';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,8 +45,8 @@ export type {
 export { ExpandableBlock } from './ExpandableBlock';
 export type { ExpandableBlockProps } from './ExpandableBlock';
 
-export { FileUpload } from './FileUpload';
-export type { FileUploadProps } from './FileUpload';
+export { FileUpload, FileUploadTemplate } from './FileUpload';
+export type { FileUploadProps, FileUploadTemplateProps } from './FileUpload';
 
 export { Footer } from './Footer';
 export type { FooterProps, FooterElement, TitleTranslations } from './Footer';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,6 +45,9 @@ export type {
 export { ExpandableBlock } from './ExpandableBlock';
 export type { ExpandableBlockProps } from './ExpandableBlock';
 
+export { FileUpload } from './FileUpload';
+export type { FileUploadProps } from './FileUpload';
+
 export { Footer } from './Footer';
 export type { FooterProps, FooterElement, TitleTranslations } from './Footer';
 

--- a/stories/core/FileUpload.stories.tsx
+++ b/stories/core/FileUpload.stories.tsx
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { action } from '@storybook/addon-actions';
+import { useState } from '@storybook/client-api';
+import { Story, Meta } from '@storybook/react';
+import React from 'react';
+import { FileUpload, FileUploadProps, Textarea } from '../../src/core';
+
+export default {
+  component: FileUpload,
+  argTypes: {
+    className: { control: { disable: true } },
+    style: { control: { disable: true } },
+    onFileDropped: { control: { disable: true } },
+    children: { control: { disable: true } },
+  },
+  title: 'Core/FileUpload',
+} as Meta<FileUploadProps>;
+
+export const Basic: Story<FileUploadProps> = (args) => {
+  const [file, setFile] = useState<File | undefined>(undefined);
+
+  return (
+    <FileUpload
+      content={'Drop file to upload'}
+      {...args}
+      onFileDropped={(f) => {
+        setFile(f);
+        action(`${f.name} (${f.size / 1000} KB) uploaded`)();
+      }}
+    >
+      <Textarea placeholder={'Drag a file here'} rows={1} value={file?.name} />
+    </FileUpload>
+  );
+};
+
+Basic.args = {
+  content: 'Drop file to upload',
+};
+
+export const WithoutChildren: Story<FileUploadProps> = ({
+  children,
+  ...rest
+}) => {
+  const [file, setFile] = useState<File | undefined>(undefined);
+
+  return (
+    <FileUpload
+      content={file?.name ?? children ?? 'Drop file to upload'}
+      {...rest}
+      onFileDropped={(f) => {
+        setFile(f);
+        action(`${f.name} (${f.size / 1000} KB) uploaded`)();
+      }}
+    />
+  );
+};

--- a/stories/core/FileUpload.stories.tsx
+++ b/stories/core/FileUpload.stories.tsx
@@ -2,12 +2,16 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { SvgUpload } from '@itwin/itwinui-icons-react';
 import { action } from '@storybook/addon-actions';
 import { useState } from '@storybook/client-api';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
-import { FileUpload, FileUploadProps, Textarea } from '../../src/core';
+import {
+  FileUpload,
+  FileUploadProps,
+  FileUploadTemplate,
+  LabeledInput,
+} from '../../src/core';
 
 export default {
   component: FileUpload,
@@ -20,56 +24,51 @@ export default {
   title: 'Core/FileUpload',
 } as Meta<FileUploadProps>;
 
-export const Basic: Story<FileUploadProps> = (args) => {
+export const Default: Story<FileUploadProps> = (args) => {
   const [files, setFiles] = useState<Array<File>>([]);
 
   return (
     <FileUpload
-      content={'Drop file to upload'}
       {...args}
       onFileDropped={(files) => {
         setFiles(Array.from(files));
         action(`${files.length} files uploaded`)();
       }}
     >
-      <Textarea
-        placeholder={'Drag a file here'}
-        rows={1}
-        defaultValue={files.map((f) => f.name)}
-      />
+      <FileUploadTemplate
+        onChange={(e) => setFiles(Array.from(e.target.files || []))}
+      >
+        {files.map((f) => f.name).join(', ')}
+      </FileUploadTemplate>
     </FileUpload>
   );
 };
 
-Basic.args = {
-  content: 'Drop file to upload',
-};
-
-export const WithoutChildren: Story<FileUploadProps> = (args) => {
+export const WrappingInput: Story<FileUploadProps> = (args) => {
   const [files, setFiles] = useState<Array<File>>([]);
 
   return (
     <FileUpload
-      content={
-        <>
-          <input
-            className='iui-browse-input'
-            type='file'
-            id='file-input'
-            onChange={(e) => setFiles(Array.from(e.target.files || []))}
-            multiple
-          />
-          <SvgUpload className='iui-icon' />
-          <label htmlFor='file-input' className='iui-anchor'>
-            {files.map((f) => f.name).join() || 'Click or drag a file'}
-          </label>
-        </>
-      }
+      dragContent='Drop file to upload'
       {...args}
       onFileDropped={(files) => {
         setFiles(Array.from(files));
         action(`${files.length} files uploaded`)();
       }}
-    />
+    >
+      <LabeledInput
+        placeholder='Type a message'
+        style={{ width: '100%' }}
+        message={
+          files.length
+            ? `Attached: ${files.map((f) => f.name)}`
+            : 'Drag files to attach'
+        }
+      />
+    </FileUpload>
   );
+};
+
+WrappingInput.args = {
+  dragContent: 'Drop file to upload',
 };

--- a/stories/core/FileUpload.stories.tsx
+++ b/stories/core/FileUpload.stories.tsx
@@ -35,7 +35,7 @@ export const Basic: Story<FileUploadProps> = (args) => {
       <Textarea
         placeholder={'Drag a file here'}
         rows={1}
-        value={files.map((f) => f.name)}
+        defaultValue={files.map((f) => f.name)}
       />
     </FileUpload>
   );

--- a/stories/core/FileUpload.stories.tsx
+++ b/stories/core/FileUpload.stories.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { SvgUpload } from '@itwin/itwinui-icons-react';
 import { action } from '@storybook/addon-actions';
 import { useState } from '@storybook/client-api';
 import { Story, Meta } from '@storybook/react';
@@ -20,18 +21,22 @@ export default {
 } as Meta<FileUploadProps>;
 
 export const Basic: Story<FileUploadProps> = (args) => {
-  const [file, setFile] = useState<File | undefined>(undefined);
+  const [files, setFiles] = useState<Array<File>>([]);
 
   return (
     <FileUpload
       content={'Drop file to upload'}
       {...args}
-      onFileDropped={(f) => {
-        setFile(f);
-        action(`${f.name} (${f.size / 1000} KB) uploaded`)();
+      onFileDropped={(files) => {
+        setFiles(Array.from(files));
+        action(`${files.length} files uploaded`)();
       }}
     >
-      <Textarea placeholder={'Drag a file here'} rows={1} value={file?.name} />
+      <Textarea
+        placeholder={'Drag a file here'}
+        rows={1}
+        value={files.map((f) => f.name)}
+      />
     </FileUpload>
   );
 };
@@ -40,19 +45,30 @@ Basic.args = {
   content: 'Drop file to upload',
 };
 
-export const WithoutChildren: Story<FileUploadProps> = ({
-  children,
-  ...rest
-}) => {
-  const [file, setFile] = useState<File | undefined>(undefined);
+export const WithoutChildren: Story<FileUploadProps> = (args) => {
+  const [files, setFiles] = useState<Array<File>>([]);
 
   return (
     <FileUpload
-      content={file?.name ?? children ?? 'Drop file to upload'}
-      {...rest}
-      onFileDropped={(f) => {
-        setFile(f);
-        action(`${f.name} (${f.size / 1000} KB) uploaded`)();
+      content={
+        <>
+          <SvgUpload className='iui-icon' />
+          <input
+            className='iui-browse-input'
+            type='file'
+            id='file-input'
+            onChange={(e) => setFiles(Array.from(e.target.files || []))}
+            multiple
+          />
+          <label htmlFor='file-input' className='iui-anchor'>
+            {files.map((f) => f.name).join() || 'Click or drag a file'}
+          </label>
+        </>
+      }
+      {...args}
+      onFileDropped={(files) => {
+        setFiles(Array.from(files));
+        action(`${files.length} files uploaded`)();
       }}
     />
   );

--- a/stories/core/FileUpload.stories.tsx
+++ b/stories/core/FileUpload.stories.tsx
@@ -52,7 +52,6 @@ export const WithoutChildren: Story<FileUploadProps> = (args) => {
     <FileUpload
       content={
         <>
-          <SvgUpload className='iui-icon' />
           <input
             className='iui-browse-input'
             type='file'
@@ -60,6 +59,7 @@ export const WithoutChildren: Story<FileUploadProps> = (args) => {
             onChange={(e) => setFiles(Array.from(e.target.files || []))}
             multiple
           />
+          <SvgUpload className='iui-icon' />
           <label htmlFor='file-input' className='iui-anchor'>
             {files.map((f) => f.name).join() || 'Click or drag a file'}
           </label>


### PR DESCRIPTION
Added `FileUpload` component with drag & drop functionality using `file-upload.css` and [native drag events](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent).

Can be used a wrapper around any component or standalone if no children provided.

## Checklist

- [x] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] Add component features demo in Storybook (different stories)
- [x] Add an entry to the changelog for any new components and changes
- [x] Add screenshots of the key elements of the component below
- [x] Add any additional comments below describing the features you've implemented

## Screenshots

![file-upload-1](https://user-images.githubusercontent.com/9084735/116744045-c7c38e00-a9c7-11eb-8770-a32e94cbe42e.gif)
![file-upload-2](https://user-images.githubusercontent.com/9084735/116744149-eb86d400-a9c7-11eb-889c-f8f1dbde5939.gif)
