### PR TITLE
Add Table props for when bottom is reached and when row is in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.2.0
+
+`2021-04-21`
+
+### What's new
+
+- **Added bottom reached and row intersection callbacks to the `Table`.**
+
+### Fixes
+
+- **Fixed `Table` bug when change of `onSelection` handler would cause infinite rerendering loop.**
+
 ## [1.1.0]
 
 `2021-04-21`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### What's new
 
-- **Added bottom reached and row intersection callbacks to the `Table`.**
+- **Added lazy loading to `Table`** with new `onBottomReached` and `onRowInView` props.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### What's new
 
-- **Added lazy loading to `Table`** with new `onBottomReached` and `onRowInView` props.
+- **Added lazy loading to `Table`** with new `onBottomReached` and `onRowInViewport` props.
 
 ### Fixes
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -250,7 +250,7 @@ module.exports = {
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
 
-  // watchPathIgnorePatterns: [],
+  watchPathIgnorePatterns: ['stories/*'],
 
   // Whether to use watchman for file crawling
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@storybook/react": "~6.1.21",
     "@storybook/theming": "~6.1.21",
     "@testing-library/react": "^11.1.0",
+    "@testing-library/react-hooks": "^5.1.2",
     "@types/classnames": "^2.2.7",
     "@types/jest": "^26.0.20",
     "@types/node": "^10.12.2",

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -349,6 +349,10 @@ it('should trigger onBottomReached', () => {
   mockIntersection(rows[49]);
 
   expect(onBottomReached).toHaveBeenCalledTimes(1);
+  expect(IntersectionObserver).toHaveBeenCalledWith(
+    expect.any(Function),
+    expect.objectContaining({ rootMargin: '300px' }),
+  );
 });
 
 it('should trigger onRowInViewport', () => {
@@ -356,6 +360,7 @@ it('should trigger onRowInViewport', () => {
   const { container } = renderComponent({
     data: mockedData(50),
     onRowInViewport,
+    intersectionMargin: 500,
   });
 
   const rows = container.querySelectorAll('.iui-tables-body .iui-tables-row');
@@ -368,6 +373,10 @@ it('should trigger onRowInViewport', () => {
   }
 
   expect(onRowInViewport).toHaveBeenCalledTimes(10);
+  expect(IntersectionObserver).toHaveBeenCalledWith(
+    expect.any(Function),
+    expect.objectContaining({ rootMargin: '500px' }),
+  );
 });
 
 it('should not trigger onBottomReached and onRowInViewport when IntersectionObserver is missing', () => {

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -351,21 +351,21 @@ it('should trigger onBottomReached', () => {
   expect(onBottomReached).toHaveBeenCalledTimes(1);
 });
 
-it('should trigger onRowIntersection', () => {
-  const onRowIntersection = jest.fn();
+it('should trigger onRowInView', () => {
+  const onRowInView = jest.fn();
   const { container } = renderComponent({
     data: mockedData(50),
-    onRowIntersection,
+    onRowInView,
   });
 
   const rows = container.querySelectorAll('.iui-tables-body .iui-tables-row');
   expect(rows.length).toBe(50);
 
-  expect(onRowIntersection).not.toHaveBeenCalled();
+  expect(onRowInView).not.toHaveBeenCalled();
   expect(observers.size).toBe(50);
   for (let i = 0; i < 10; i++) {
     mockIntersection(rows[i]);
   }
 
-  expect(onRowIntersection).toHaveBeenCalledTimes(10);
+  expect(onRowInView).toHaveBeenCalledTimes(10);
 });

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -351,42 +351,42 @@ it('should trigger onBottomReached', () => {
   expect(onBottomReached).toHaveBeenCalledTimes(1);
 });
 
-it('should trigger onRowInView', () => {
-  const onRowInView = jest.fn();
+it('should trigger onRowInViewport', () => {
+  const onRowInViewport = jest.fn();
   const { container } = renderComponent({
     data: mockedData(50),
-    onRowInView,
+    onRowInViewport,
   });
 
   const rows = container.querySelectorAll('.iui-tables-body .iui-tables-row');
   expect(rows.length).toBe(50);
 
-  expect(onRowInView).not.toHaveBeenCalled();
+  expect(onRowInViewport).not.toHaveBeenCalled();
   expect(observers.size).toBe(50);
   for (let i = 0; i < 10; i++) {
     mockIntersection(rows[i]);
   }
 
-  expect(onRowInView).toHaveBeenCalledTimes(10);
+  expect(onRowInViewport).toHaveBeenCalledTimes(10);
 });
 
-it('should not trigger onBottomReached and onRowInView when IntersectionObserver is missing', () => {
+it('should not trigger onBottomReached and onRowInViewport when IntersectionObserver is missing', () => {
   (window.IntersectionObserver as unknown) = undefined;
   const onBottomReached = jest.fn();
-  const onRowInView = jest.fn();
+  const onRowInViewport = jest.fn();
   const { container } = renderComponent({
     data: mockedData(50),
     onBottomReached,
-    onRowInView,
+    onRowInViewport,
   });
 
   const rows = container.querySelectorAll('.iui-tables-body .iui-tables-row');
   expect(rows.length).toBe(50);
 
-  expect(onRowInView).not.toHaveBeenCalled();
+  expect(onRowInViewport).not.toHaveBeenCalled();
   expect(observers.size).toBe(0);
   mockIntersection(rows[49]);
 
   expect(onBottomReached).not.toHaveBeenCalled();
-  expect(onRowInView).not.toHaveBeenCalled();
+  expect(onRowInViewport).not.toHaveBeenCalled();
 });

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -80,9 +80,9 @@ export type TableProps<
    * Callback function when row is viewport.
    * If you want to use it in older browsers e.g. IE, then you need to have IntersectionObserver polyfill.
    */
-  onRowInView?: (rowData: T) => void;
+  onRowInViewport?: (rowData: T) => void;
   /**
-   * Margin in pixels when row is considered to be already in view. Used for `onBottomReached` and `onRowInView`.
+   * Margin in pixels when row is considered to be already in view. Used for `onBottomReached` and `onRowInViewport`.
    * @default 300
    */
   intersectionMargin?: number;
@@ -147,7 +147,7 @@ export const Table = <
     onSort,
     stateReducer,
     onBottomReached,
-    onRowInView,
+    onRowInViewport,
     intersectionMargin = 300,
     ...rest
   } = props;
@@ -166,12 +166,12 @@ export const Table = <
   // useRef prevents from rerendering when one of these callbacks changes
   const onSelectRef = React.useRef(onSelect);
   const onBottomReachedRef = React.useRef(onBottomReached);
-  const onRowInViewRef = React.useRef(onRowInView);
+  const onRowInViewportRef = React.useRef(onRowInViewport);
   React.useEffect(() => {
     onSelectRef.current = onSelect;
     onBottomReachedRef.current = onBottomReached;
-    onRowInViewRef.current = onRowInView;
-  }, [onBottomReached, onRowInView, onSelect]);
+    onRowInViewportRef.current = onRowInViewport;
+  }, [onBottomReached, onRowInViewport, onSelect]);
 
   const useSelectionHook = (hooks: Hooks<T>) => {
     if (!isSelectable) {
@@ -328,7 +328,7 @@ export const Table = <
                 row={row}
                 rowProps={rowProps}
                 isLast={row.index === data.length - 1}
-                onRowInView={onRowInViewRef}
+                onRowInViewport={onRowInViewportRef}
                 onBottomReached={onBottomReachedRef}
                 intersectionMargin={intersectionMargin}
                 state={state}

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -80,12 +80,12 @@ export type TableProps<
    * Callback function when row is viewport.
    * If you want to use it in older browsers e.g. IE, then you need to have IntersectionObserver polyfill.
    */
-  onRowIntersection?: (rowData: T) => void;
+  onRowInView?: (rowData: T) => void;
   /**
-   * Margin when row is considered to be already in view. Used for `onBottomReached` and `onRowIntersection`.
+   * Margin in pixels when row is considered to be already in view. Used for `onBottomReached` and `onRowInView`.
    * @default 300
    */
-  intersectionMarginPx?: number;
+  intersectionMargin?: number;
 } & Omit<CommonProps, 'title'>;
 
 /**
@@ -147,8 +147,8 @@ export const Table = <
     onSort,
     stateReducer,
     onBottomReached,
-    onRowIntersection,
-    intersectionMarginPx = 300,
+    onRowInView,
+    intersectionMargin = 300,
     ...rest
   } = props;
 
@@ -166,12 +166,12 @@ export const Table = <
   // useRef prevents from rerendering when one of these callbacks changes
   const onSelectRef = React.useRef(onSelect);
   const onBottomReachedRef = React.useRef(onBottomReached);
-  const onRowIntersectionRef = React.useRef(onRowIntersection);
+  const onRowInViewRef = React.useRef(onRowInView);
   React.useEffect(() => {
     onSelectRef.current = onSelect;
     onBottomReachedRef.current = onBottomReached;
-    onRowIntersectionRef.current = onRowIntersection;
-  }, [onBottomReached, onRowIntersection, onSelect]);
+    onRowInViewRef.current = onRowInView;
+  }, [onBottomReached, onRowInView, onSelect]);
 
   const useSelectionHook = (hooks: Hooks<T>) => {
     if (!isSelectable) {
@@ -328,9 +328,9 @@ export const Table = <
                 row={row}
                 rowProps={rowProps}
                 isLast={row.index === data.length - 1}
-                onIntersection={onRowIntersectionRef}
+                onRowInView={onRowInViewRef}
                 onBottomReached={onBottomReachedRef}
-                intersectionMarginPx={intersectionMarginPx}
+                intersectionMargin={intersectionMargin}
                 state={state}
                 key={rowProps.key}
               />

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -29,6 +29,8 @@ import '@itwin/itwinui-css/css/table.css';
 import { CommonProps } from '../utils/props';
 import SvgSortDown from '@itwin/itwinui-icons-react/cjs/icons/SortDown';
 import SvgSortUp from '@itwin/itwinui-icons-react/cjs/icons/SortUp';
+import { getCellStyle } from './utils';
+import { TableRowMemoized } from './TableRowMemoized';
 
 /**
  * Table props.
@@ -69,6 +71,21 @@ export type TableProps<
    * Must be memoized.
    */
   onSort?: (state: TableState<T>) => void;
+  /**
+   * Callback function when scroll reaches bottom. Can be used for lazy-loading the data.
+   * If you want to use it in older browsers e.g. IE, then you need to have IntersectionObserver polyfill.
+   */
+  onBottomReached?: () => void;
+  /**
+   * Callback function when row is viewport.
+   * If you want to use it in older browsers e.g. IE, then you need to have IntersectionObserver polyfill.
+   */
+  onRowIntersection?: (rowData: T) => void;
+  /**
+   * Margin when row is considered to be already in view. Used for `onBottomReached` and `onRowIntersection`.
+   * @default 300
+   */
+  intersectionMarginPx?: number;
 } & Omit<CommonProps, 'title'>;
 
 /**
@@ -129,6 +146,9 @@ export const Table = <
     isSortable = false,
     onSort,
     stateReducer,
+    onBottomReached,
+    onRowIntersection,
+    intersectionMarginPx = 300,
     ...rest
   } = props;
 
@@ -142,6 +162,16 @@ export const Table = <
     }),
     [],
   );
+
+  // useRef prevents from rerendering when one of these callbacks changes
+  const onSelectRef = React.useRef(onSelect);
+  const onBottomReachedRef = React.useRef(onBottomReached);
+  const onRowIntersectionRef = React.useRef(onRowIntersection);
+  React.useEffect(() => {
+    onSelectRef.current = onSelect;
+    onBottomReachedRef.current = onBottomReached;
+    onRowIntersectionRef.current = onRowIntersection;
+  }, [onBottomReached, onRowIntersection, onSelect]);
 
   const useSelectionHook = (hooks: Hooks<T>) => {
     if (!isSelectable) {
@@ -217,32 +247,12 @@ export const Table = <
 
   useMountedLayoutEffect(() => {
     if (isSelectable && selectedFlatRows) {
-      onSelect?.(
+      onSelectRef.current?.(
         selectedFlatRows.map((row) => row.original),
         state,
       );
     }
-  }, [selectedFlatRows, onSelect]);
-
-  const getStyle = (
-    column: ColumnInstance<T>,
-  ): React.CSSProperties | undefined => {
-    const style = {} as React.CSSProperties;
-    style.flex = `1 1 145px`;
-    if (column.width) {
-      const width =
-        typeof column.width === 'string' ? column.width : `${column.width}px`;
-      style.width = width;
-      style.flex = `0 0 ${width}`;
-    }
-    if (column.maxWidth) {
-      style.maxWidth = `${column.maxWidth}px`;
-    }
-    if (column.minWidth) {
-      style.minWidth = `${column.minWidth}px`;
-    }
-    return style;
-  };
+  }, [selectedFlatRows, onSelectRef]);
 
   const ariaDataAttributes = Object.entries(rest).reduce(
     (result, [key, value]) => {
@@ -279,7 +289,7 @@ export const Table = <
                     column.columnClassName,
                   ),
                   style: {
-                    ...getStyle(column),
+                    ...getCellStyle(column),
                     cursor: column.canSort ? 'pointer' : undefined,
                   },
                 });
@@ -305,8 +315,7 @@ export const Table = <
         })}
       </div>
       <div {...getTableBodyProps({ className: 'iui-tables-body' })}>
-        {!isLoading &&
-          data.length !== 0 &&
+        {data.length !== 0 &&
           rows.map((row: Row<T>) => {
             prepareRow(row);
             const rowProps = row.getRowProps({
@@ -315,24 +324,35 @@ export const Table = <
               }),
             });
             return (
-              <div {...rowProps} key={rowProps.key}>
-                {row.cells.map((cell) => {
-                  const cellProps = cell.getCellProps({
-                    className: cx('iui-tables-cell', cell.column.cellClassName),
-                    style: getStyle(cell.column),
-                  });
-                  return (
-                    <div {...cellProps} key={cellProps.key}>
-                      {cell.render('Cell')}
-                    </div>
-                  );
-                })}
-              </div>
+              <TableRowMemoized
+                row={row}
+                rowProps={rowProps}
+                isLast={row.index === data.length - 1}
+                onIntersection={onRowIntersectionRef}
+                onBottomReached={onBottomReachedRef}
+                intersectionMarginPx={intersectionMarginPx}
+                state={state}
+                key={rowProps.key}
+              />
             );
           })}
-        {isLoading && (
+        {isLoading && data.length === 0 && (
           <div className={'iui-tables-message-container'}>
             <ProgressRadial indeterminate={true} />
+          </div>
+        )}
+        {isLoading && data.length !== 0 && (
+          <div className='iui-tables-row'>
+            <div
+              className='iui-tables-cell'
+              style={{ justifyContent: 'center' }}
+            >
+              <ProgressRadial
+                indeterminate={true}
+                size='small'
+                style={{ float: 'none', marginLeft: 0 }}
+              />
+            </div>
           </div>
         )}
         {!isLoading && data.length === 0 && (

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -77,12 +77,12 @@ export type TableProps<
    */
   onBottomReached?: () => void;
   /**
-   * Callback function when row is viewport.
+   * Callback function when row is in viewport.
    * If you want to use it in older browsers e.g. IE, then you need to have IntersectionObserver polyfill.
    */
   onRowInViewport?: (rowData: T) => void;
   /**
-   * Margin in pixels when row is considered to be already in view. Used for `onBottomReached` and `onRowInViewport`.
+   * Margin in pixels when row is considered to be already in viewport. Used for `onBottomReached` and `onRowInViewport`.
    * @default 300
    */
   intersectionMargin?: number;

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -12,7 +12,7 @@ const TableRow = <T extends Record<string, unknown>>(props: {
   row: Row<T>;
   rowProps: TableRowProps;
   isLast: boolean;
-  onRowInView: React.MutableRefObject<((rowData: T) => void) | undefined>;
+  onRowInViewport: React.MutableRefObject<((rowData: T) => void) | undefined>;
   onBottomReached: React.MutableRefObject<(() => void) | undefined>;
   intersectionMargin: number;
   state: TableState<T>; // Needed for explicitly checking selection changes
@@ -21,15 +21,15 @@ const TableRow = <T extends Record<string, unknown>>(props: {
     row,
     rowProps,
     isLast,
-    onRowInView,
+    onRowInViewport,
     onBottomReached,
     intersectionMargin,
   } = props;
 
   const onIntersect = React.useCallback(() => {
-    onRowInView.current?.(row.original);
+    onRowInViewport.current?.(row.original);
     isLast && onBottomReached.current?.();
-  }, [isLast, onBottomReached, onRowInView, row.original]);
+  }, [isLast, onBottomReached, onRowInViewport, row.original]);
 
   const setRef = useIntersection(onIntersect, {
     rootMargin: `${intersectionMargin}px`,
@@ -56,7 +56,7 @@ export const TableRowMemoized = React.memo(
   TableRow,
   (prevProp, nextProp) =>
     prevProp.isLast === nextProp.isLast &&
-    prevProp.onRowInView === nextProp.onRowInView &&
+    prevProp.onRowInViewport === nextProp.onRowInViewport &&
     prevProp.onBottomReached === nextProp.onBottomReached &&
     prevProp.row.original === nextProp.row.original &&
     prevProp.state.selectedRowIds?.[prevProp.row.id] ===

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -8,6 +8,12 @@ import { Row, TableRowProps, TableState } from 'react-table';
 import { useIntersection } from '../utils/hooks/useIntersection';
 import { getCellStyle } from './utils';
 
+/**
+ * Memorization is needed to avoid unnecessary re-renders of all rows when additional data is added when lazy-loading.
+ * Using `isLast` here instead of passing data length to avoid re-renders of all rows when more data is added. Now only the last row re-renders.
+ * Although state is not used it is needed for `React.memo` to check state that changes row state e.g. selection.
+ * When adding new features check whether it changes state that affects row. If it does then add equality check to `React.memo`.
+ */
 const TableRow = <T extends Record<string, unknown>>(props: {
   row: Row<T>;
   rowProps: TableRowProps;

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import cx from 'classnames';
 import { Row, TableRowProps, TableState } from 'react-table';

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -37,12 +37,12 @@ const TableRow = <T extends Record<string, unknown>>(props: {
     isLast && onBottomReached.current?.();
   }, [isLast, onBottomReached, onRowInViewport, row.original]);
 
-  const setRef = useIntersection(onIntersect, {
+  const rowRef = useIntersection(onIntersect, {
     rootMargin: `${intersectionMargin}px`,
   });
 
   return (
-    <div {...rowProps} key={rowProps.key} ref={setRef}>
+    <div {...rowProps} key={rowProps.key} ref={rowRef}>
       {row.cells.map((cell) => {
         const cellProps = cell.getCellProps({
           className: cx('iui-tables-cell', cell.column.cellClassName),

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -12,27 +12,27 @@ const TableRow = <T extends Record<string, unknown>>(props: {
   row: Row<T>;
   rowProps: TableRowProps;
   isLast: boolean;
-  onIntersection: React.MutableRefObject<((rowData: T) => void) | undefined>;
+  onRowInView: React.MutableRefObject<((rowData: T) => void) | undefined>;
   onBottomReached: React.MutableRefObject<(() => void) | undefined>;
-  intersectionMarginPx: number;
+  intersectionMargin: number;
   state: TableState<T>; // Needed for explicitly checking selection changes
 }) => {
   const {
     row,
     rowProps,
     isLast,
-    onIntersection,
+    onRowInView,
     onBottomReached,
-    intersectionMarginPx,
+    intersectionMargin,
   } = props;
 
   const onIntersect = React.useCallback(() => {
-    onIntersection.current?.(row.original);
+    onRowInView.current?.(row.original);
     isLast && onBottomReached.current?.();
-  }, [isLast, onBottomReached, onIntersection, row.original]);
+  }, [isLast, onBottomReached, onRowInView, row.original]);
 
   const setRef = useIntersection(onIntersect, {
-    rootMargin: `${intersectionMarginPx}px`,
+    rootMargin: `${intersectionMargin}px`,
   });
 
   return (
@@ -56,7 +56,7 @@ export const TableRowMemoized = React.memo(
   TableRow,
   (prevProp, nextProp) =>
     prevProp.isLast === nextProp.isLast &&
-    prevProp.onIntersection === nextProp.onIntersection &&
+    prevProp.onRowInView === nextProp.onRowInView &&
     prevProp.onBottomReached === nextProp.onBottomReached &&
     prevProp.row.original === nextProp.row.original &&
     prevProp.state.selectedRowIds?.[prevProp.row.id] ===

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import cx from 'classnames';
+import { Row, TableRowProps, TableState } from 'react-table';
+import { useIntersection } from '../utils/hooks/useIntersection';
+import { getCellStyle } from './utils';
+
+const TableRow = <T extends Record<string, unknown>>(props: {
+  row: Row<T>;
+  rowProps: TableRowProps;
+  isLast: boolean;
+  onIntersection: React.MutableRefObject<((rowData: T) => void) | undefined>;
+  onBottomReached: React.MutableRefObject<(() => void) | undefined>;
+  intersectionMarginPx: number;
+  state: TableState<T>; // Needed for explicitly checking selection changes
+}) => {
+  const {
+    row,
+    rowProps,
+    isLast,
+    onIntersection,
+    onBottomReached,
+    intersectionMarginPx,
+  } = props;
+
+  const onIntersect = React.useCallback(() => {
+    onIntersection.current?.(row.original);
+    isLast && onBottomReached.current?.();
+  }, [isLast, onBottomReached, onIntersection, row.original]);
+
+  const setRef = useIntersection(onIntersect, {
+    rootMargin: `${intersectionMarginPx}px`,
+  });
+
+  return (
+    <div {...rowProps} key={rowProps.key} ref={setRef}>
+      {row.cells.map((cell) => {
+        const cellProps = cell.getCellProps({
+          className: cx('iui-tables-cell', cell.column.cellClassName),
+          style: getCellStyle(cell.column),
+        });
+        return (
+          <div {...cellProps} key={cellProps.key}>
+            {cell.render('Cell')}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export const TableRowMemoized = React.memo(
+  TableRow,
+  (prevProp, nextProp) =>
+    prevProp.isLast === nextProp.isLast &&
+    prevProp.onIntersection === nextProp.onIntersection &&
+    prevProp.onBottomReached === nextProp.onBottomReached &&
+    prevProp.row.original === nextProp.row.original &&
+    prevProp.state.selectedRowIds?.[prevProp.row.id] ===
+      nextProp.state.selectedRowIds?.[nextProp.row.id],
+) as typeof TableRow;

--- a/src/core/Table/utils.ts
+++ b/src/core/Table/utils.ts
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import { ColumnInstance } from 'react-table';
 
 export const getCellStyle = <T extends Record<string, unknown>>(

--- a/src/core/Table/utils.ts
+++ b/src/core/Table/utils.ts
@@ -1,0 +1,21 @@
+import { ColumnInstance } from 'react-table';
+
+export const getCellStyle = <T extends Record<string, unknown>>(
+  column: ColumnInstance<T>,
+): React.CSSProperties | undefined => {
+  const style = {} as React.CSSProperties;
+  style.flex = `1 1 145px`;
+  if (column.width) {
+    const width =
+      typeof column.width === 'string' ? column.width : `${column.width}px`;
+    style.width = width;
+    style.flex = `0 0 ${width}`;
+  }
+  if (column.maxWidth) {
+    style.maxWidth = `${column.maxWidth}px`;
+  }
+  if (column.minWidth) {
+    style.minWidth = `${column.minWidth}px`;
+  }
+  return style;
+};

--- a/src/core/utils/hooks/useIntersection.test.tsx
+++ b/src/core/utils/hooks/useIntersection.test.tsx
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useIntersection } from './useIntersection';
+
+const observers = new Map<
+  Element,
+  (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => void
+>();
+
+const originalIntersectionObserver = window.IntersectionObserver;
+
+const mockIntersection = (element: Element, isIntersecting = true) => {
+  observers.get(element)?.([{ isIntersecting } as IntersectionObserverEntry], ({
+    disconnect: jest.fn(),
+  } as unknown) as IntersectionObserver);
+};
+
+const mockedDisconnect = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  observers.clear();
+  window.IntersectionObserver = jest.fn(
+    (callback: IntersectionObserverCallback) => {
+      return ({
+        observe: (el: Element) => observers.set(el, callback),
+        disconnect: mockedDisconnect,
+      } as unknown) as IntersectionObserver;
+    },
+  );
+});
+
+afterAll(() => {
+  window.IntersectionObserver = originalIntersectionObserver;
+});
+
+it('should create IntersectionObserver with options', () => {
+  const mockedElement = {} as HTMLElement;
+  const mockedRootElement = {} as HTMLElement;
+  const onIntersect = jest.fn();
+  const { result } = renderHook(() =>
+    useIntersection(onIntersect, {
+      root: mockedRootElement,
+      rootMargin: '100px',
+      threshold: 0.5,
+    }),
+  );
+
+  act(() => {
+    result.current(mockedElement);
+  });
+
+  expect(IntersectionObserver).toHaveBeenCalledWith(
+    expect.any(Function),
+    expect.objectContaining({
+      root: mockedRootElement,
+      rootMargin: '100px',
+      threshold: 0.5,
+    }),
+  );
+});
+
+it('should trigger onIntersect', () => {
+  const mockedElement = {} as HTMLElement;
+  const onIntersect = jest.fn();
+  const { result } = renderHook(() => useIntersection(onIntersect));
+
+  act(() => {
+    result.current(mockedElement);
+  });
+
+  expect(onIntersect).not.toHaveBeenCalled();
+  mockIntersection(mockedElement);
+  expect(onIntersect).toHaveBeenCalledTimes(1);
+});
+
+it('should trigger onIntersect when element ref changes', () => {
+  const mockedElement1 = {} as HTMLElement;
+  const mockedElement2 = {} as HTMLElement;
+  const onIntersect = jest.fn();
+  const { result } = renderHook(() => useIntersection(onIntersect));
+
+  act(() => {
+    result.current(mockedElement1);
+  });
+  expect(onIntersect).not.toHaveBeenCalled();
+  expect(mockedDisconnect).not.toHaveBeenCalled();
+
+  act(() => {
+    result.current(mockedElement2);
+  });
+  expect(mockedDisconnect).toHaveBeenCalled();
+  mockIntersection(mockedElement2);
+  expect(onIntersect).toHaveBeenCalledTimes(1);
+});
+
+it('should not trigger onIntersect when entry is not intersecting', () => {
+  const mockedElement = {} as HTMLElement;
+  const onIntersect = jest.fn();
+  const { result } = renderHook(() => useIntersection(onIntersect));
+
+  act(() => {
+    result.current(mockedElement);
+  });
+
+  expect(onIntersect).not.toHaveBeenCalled();
+  mockIntersection(mockedElement, false);
+  expect(onIntersect).not.toHaveBeenCalled();
+});
+
+it('should do nothing when IntersectionObserver is missing', () => {
+  (window.IntersectionObserver as unknown) = undefined;
+  const mockedElement = {} as HTMLElement;
+  const onIntersect = jest.fn();
+  const { result } = renderHook(() => useIntersection(onIntersect));
+
+  act(() => {
+    result.current(mockedElement);
+  });
+  expect(onIntersect).not.toHaveBeenCalled();
+  mockIntersection(mockedElement);
+  expect(onIntersect).not.toHaveBeenCalled();
+});
+
+it('should do nothing when element is missing', () => {
+  (window.IntersectionObserver as unknown) = undefined;
+  const onIntersect = jest.fn();
+  const { result } = renderHook(() => useIntersection(onIntersect));
+
+  act(() => {
+    result.current(null);
+  });
+  expect(onIntersect).not.toHaveBeenCalled();
+});

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 /**
- * Hook that uses `IntersectionObserver` to trigger `onIntersect` callback when element is in view.
+ * Hook that uses `IntersectionObserver` to trigger `onIntersect` callback when element is in viewport.
  * Callback is called only once.
  * Hook returns a function that you need to use to set a reference of the element you want to observe.
  * @example
@@ -32,6 +32,10 @@ export const useIntersection = (
         observer.current.disconnect();
       }
 
+      if (!node) {
+        return;
+      }
+
       observer.current = new IntersectionObserver(
         ([entry], obs) => {
           if (entry.isIntersecting) {
@@ -41,10 +45,7 @@ export const useIntersection = (
         },
         { root, rootMargin, threshold },
       );
-
-      if (node) {
-        observer.current.observe(node);
-      }
+      observer.current.observe(node);
     },
     [onIntersect, root, rootMargin, threshold],
   );

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -7,6 +7,13 @@ import React from 'react';
 /**
  * Hook that uses `IntersectionObserver` to trigger `onIntersect` callback when element is in view.
  * Callback is called only once.
+ * Hook returns a function that you need to use to set a reference of the element you want to observe.
+ * @example
+ * const onIntersection = React.useCallback(() => {
+ *   console.log('Element is in viewport!');
+ * }, []);
+ * const setRef = useIntersection(onIntersection);
+ * return (<div ref={setRef}>One of many elements</div>);
  */
 export const useIntersection = (
   onIntersect: () => void,

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 
 export const useIntersection = (

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export const useIntersection = (
+  onIntersect: () => void,
+  options: IntersectionObserverInit = {},
+) => {
+  const { root, rootMargin, threshold } = options;
+  const observer = React.useRef<IntersectionObserver>();
+
+  const setRef = React.useCallback(
+    (node: HTMLElement | null) => {
+      if (observer.current) {
+        observer.current.disconnect();
+      }
+
+      observer.current = new IntersectionObserver(
+        ([entry], obs) => {
+          if (entry.isIntersecting) {
+            obs.disconnect();
+            onIntersect();
+          }
+        },
+        { root, rootMargin, threshold },
+      );
+
+      if (node) {
+        observer.current.observe(node);
+      }
+    },
+    [onIntersect, root, rootMargin, threshold],
+  );
+
+  return setRef;
+};

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -17,6 +17,10 @@ export const useIntersection = (
 
   const setRef = React.useCallback(
     (node: HTMLElement | null) => {
+      if (!window.IntersectionObserver) {
+        return;
+      }
+
       if (observer.current) {
         observer.current.disconnect();
       }

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -12,8 +12,8 @@ import React from 'react';
  * const onIntersection = React.useCallback(() => {
  *   console.log('Element is in viewport!');
  * }, []);
- * const setRef = useIntersection(onIntersection);
- * return (<div ref={setRef}>One of many elements</div>);
+ * const ref = useIntersection(onIntersection);
+ * return (<div ref={ref}>One of many elements</div>);
  */
 export const useIntersection = (
   onIntersect: () => void,

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -4,6 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 
+/**
+ * Hook that uses `IntersectionObserver` to trigger `onIntersect` callback when element is in view.
+ * Callback is called only once.
+ */
 export const useIntersection = (
   onIntersect: () => void,
   options: IntersectionObserverInit = {},

--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -390,7 +390,7 @@ LazyLoading.argTypes = {
   isLoading: { control: { disable: true } },
 };
 
-export const RowIntersection: Story<TableProps> = (args) => {
+export const RowInView: Story<TableProps> = (args) => {
   const { columns, ...rest } = args;
 
   const onClickHandler = (
@@ -441,7 +441,7 @@ export const RowIntersection: Story<TableProps> = (args) => {
     [],
   );
 
-  const onRowIntersection = useCallback((rowData) => {
+  const onRowInView = useCallback((rowData) => {
     action(`Row in view: ${JSON.stringify(rowData)}`)();
   }, []);
 
@@ -449,14 +449,14 @@ export const RowIntersection: Story<TableProps> = (args) => {
     <Table
       columns={columns || tableColumns}
       emptyTableContent='No data.'
-      onRowIntersection={onRowIntersection}
+      onRowInView={onRowInView}
       {...rest}
       data={tableData}
     />
   );
 };
 
-RowIntersection.argTypes = {
+RowInView.argTypes = {
   data: { control: { disable: true } },
 };
 

--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React, { useCallback } from 'react';
 import { CellProps } from 'react-table';
-import { Table } from '../../src/core';
+import { Code, Table } from '../../src/core';
 import { TableProps } from '../../src/core/Table/Table';
 import { Story, Meta } from '@storybook/react';
 import { useMemo, useState } from '@storybook/addons';
@@ -390,7 +390,7 @@ LazyLoading.argTypes = {
   isLoading: { control: { disable: true } },
 };
 
-export const RowInView: Story<TableProps> = (args) => {
+export const RowInViewport: Story<TableProps> = (args) => {
   const { columns, ...rest } = args;
 
   const onClickHandler = (
@@ -441,22 +441,41 @@ export const RowInView: Story<TableProps> = (args) => {
     [],
   );
 
-  const onRowInView = useCallback((rowData) => {
+  const onRowInViewport = useCallback((rowData) => {
     action(`Row in view: ${JSON.stringify(rowData)}`)();
   }, []);
 
   return (
-    <Table
-      columns={columns || tableColumns}
-      emptyTableContent='No data.'
-      onRowInView={onRowInView}
-      {...rest}
-      data={tableData}
-    />
+    <>
+      <div>
+        Demo of <Code>IntersectionObserver</Code> hook that triggers{' '}
+        <Code>onRowInViewport</Code> callback once the row is visible.
+      </div>
+      <div>
+        Open{' '}
+        <a
+          className='iui-anchor'
+          onClick={() =>
+            parent.document.getElementById('tabbutton-actions')?.click()
+          }
+        >
+          Actions
+        </a>{' '}
+        tab to see when callback is called.
+      </div>
+      <br />
+      <Table
+        columns={columns || tableColumns}
+        emptyTableContent='No data.'
+        onRowInViewport={onRowInViewport}
+        {...rest}
+        data={tableData}
+      />
+    </>
   );
 };
 
-RowInView.argTypes = {
+RowInViewport.argTypes = {
   data: { control: { disable: true } },
 };
 

--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -461,7 +461,7 @@ export const RowInViewport: Story<TableProps> = (args) => {
         >
           Actions
         </a>{' '}
-        tab to see when callback is called.
+        tab to see when callback is called and scroll the table.
       </div>
       <br />
       <Table

--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -7,7 +7,7 @@ import { CellProps } from 'react-table';
 import { Table } from '../../src/core';
 import { TableProps } from '../../src/core/Table/Table';
 import { Story, Meta } from '@storybook/react';
-import { useMemo } from '@storybook/addons';
+import { useMemo, useState } from '@storybook/addons';
 import { action } from '@storybook/addon-actions';
 
 export default {
@@ -89,6 +89,9 @@ export default {
       table: { disable: true },
     },
     autoResetSortBy: {
+      table: { disable: true },
+    },
+    autoResetHiddenColumns: {
       table: { disable: true },
     },
   },
@@ -302,6 +305,159 @@ Sortable.args = {
     { name: 'Name2', description: 'Description2' },
   ],
   isSortable: true,
+};
+
+export const LazyLoading: Story<TableProps> = (args) => {
+  const { columns, ...rest } = args;
+
+  const onClickHandler = (
+    props: CellProps<{ name: string; description: string }>,
+  ) => action(props.row.original.name)();
+
+  const tableColumns = useMemo(
+    () => [
+      {
+        Header: 'Table',
+        columns: [
+          {
+            id: 'name',
+            Header: 'Name',
+            accessor: 'name',
+          },
+          {
+            id: 'description',
+            Header: 'Description',
+            accessor: 'description',
+            maxWidth: 200,
+          },
+          {
+            id: 'click-me',
+            Header: 'Click',
+            width: 100,
+            Cell: (props: CellProps<{ name: string; description: string }>) => {
+              const onClick = () => onClickHandler(props);
+              return (
+                <a className='iui-anchor' onClick={onClick}>
+                  Click me!
+                </a>
+              );
+            },
+          },
+        ],
+      },
+    ],
+    [],
+  );
+
+  const generateData = (start: number, end: number) => {
+    return [...new Array(end - start)].map((_, index) => ({
+      name: `Name${start + index}`,
+      description: `Description${start + index}`,
+    }));
+  };
+
+  const [tableData, setTableData] = useState(() => generateData(1, 100));
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onBottomReached = useCallback(() => {
+    action('Bottom reached!')();
+    setIsLoading(true);
+    // Simulating request
+    setTimeout(() => {
+      setTableData(() => [
+        ...tableData,
+        ...generateData(tableData.length, tableData.length + 100),
+      ]);
+      setIsLoading(false);
+    }, 1000);
+  }, [tableData]);
+
+  return (
+    <Table
+      columns={columns || tableColumns}
+      emptyTableContent='No data.'
+      onBottomReached={onBottomReached}
+      isLoading={isLoading}
+      {...rest}
+      data={tableData}
+    />
+  );
+};
+
+LazyLoading.argTypes = {
+  data: { control: { disable: true } },
+  isLoading: { control: { disable: true } },
+};
+
+export const RowIntersection: Story<TableProps> = (args) => {
+  const { columns, ...rest } = args;
+
+  const onClickHandler = (
+    props: CellProps<{ name: string; description: string }>,
+  ) => action(props.row.original.name)();
+
+  const tableColumns = useMemo(
+    () => [
+      {
+        Header: 'Table',
+        columns: [
+          {
+            id: 'name',
+            Header: 'Name',
+            accessor: 'name',
+          },
+          {
+            id: 'description',
+            Header: 'Description',
+            accessor: 'description',
+            maxWidth: 200,
+          },
+          {
+            id: 'click-me',
+            Header: 'Click',
+            width: 100,
+            Cell: (props: CellProps<{ name: string; description: string }>) => {
+              const onClick = () => onClickHandler(props);
+              return (
+                <a className='iui-anchor' onClick={onClick}>
+                  Click me!
+                </a>
+              );
+            },
+          },
+        ],
+      },
+    ],
+    [],
+  );
+
+  const tableData = useMemo(
+    () =>
+      [...new Array(100)].map((_, index) => ({
+        name: `Name${index}`,
+        description: `Description${index}`,
+      })),
+    [],
+  );
+
+  const onRowIntersection = useCallback((rowData) => {
+    action(`Row in view: ${JSON.stringify(rowData)}`)();
+  }, []);
+
+  return (
+    <Table
+      columns={columns || tableColumns}
+      emptyTableContent='No data.'
+      onRowIntersection={onRowIntersection}
+      {...rest}
+      data={tableData}
+    />
+  );
+};
+
+RowIntersection.argTypes = {
+  data: { control: { disable: true } },
 };
 
 export const Loading: Story<TableProps> = (args) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,6 +2040,18 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/react-hooks@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz#36e359d992bb652a9885c6fa9aa394639cbe8dd3"
+  integrity sha512-jwhtDYZ5gQUIX8cmVCVdtwNvuF5EiCOWjokRlTV+o/V0GdtRZDykUllL1OXq5PS4+J33wGLNQeeWzEHcWrH7tg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.1.0":
   version "11.2.6"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
@@ -2302,7 +2314,7 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@^17.0.3":
+"@types/react-dom@>=16.9.0", "@types/react-dom@^17.0.3":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
   integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
@@ -2323,6 +2335,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^2.9.2":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.9.2.tgz#c48cf2a11977c8b4ff539a1c91d259eaa627028d"
@@ -2334,6 +2353,15 @@
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
   integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.5.tgz#3d887570c4489011f75a3fc8f965bf87d09a1bea"
+  integrity sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -5778,6 +5806,11 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -9609,6 +9642,13 @@ react-element-to-jsx-string@^14.3.1:
   dependencies:
     "@base2/pretty-print-object" "1.0.0"
     is-plain-object "3.0.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.1.tgz#932c5ca5cbab8ec4fe37fd7b415aa5c3a47597e7"
+  integrity sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
Thank you for your contribution to the iTwinUi-react project! Please make sure to complete all of the items below before submitting the PR.

## Checklist

- [x] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] Add component features demo in Storybook (different stories)
- [x] Add an entry to the changelog for any new components and changes
- [x] Add screenshots of the key elements of the component below
- [x] Add any additional comments below describing the features you've implemented

## Screenshots
Lazy loading (green borders are from Profiler and show what parts rerender):
![lazy_load](https://user-images.githubusercontent.com/36186912/116999458-5138d000-ace8-11eb-9ef4-2252591154e5.gif)

Row intersection:
![row_intersection](https://user-images.githubusercontent.com/36186912/116999667-9b21b600-ace8-11eb-8c99-b9a2e1760d28.gif)

## Additional Comments
 - Made `IntersectionObserver` hook. Using `useRef` for callbacks to avoid rerendering all rows when they change.
 - Moved row code to separate component and memorized it because otherwise when adding new batch of data, all rows would rerender.
 - Passing `isLast` to row instead of just data length to avoid unnecessary rerenders when length changes. Now only last row is rerendered.
 - Added `stories` folder to jest ignore list to avoid tests rerun in watch mode when stories change.
 - I also made a fix for a bug when `onSelection` caused infinite table rerenders.