### PR TITLE
Update to itwinui-css 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "^0.11.0",
-    "@itwin/itwinui-icons-react": "^0.1.0",
-    "@itwin/itwinui-illustrations-react": "^0.1.0",
+    "@itwin/itwinui-css": "^0.12.0",
+    "@itwin/itwinui-icons-react": "^1.1.0",
+    "@itwin/itwinui-illustrations-react": "^1.0.0",
     "@tippyjs/react": "^4.2.5",
     "@types/react-table": "^7.0.18",
     "classnames": "^2.2.6",

--- a/src/core/Alert/Alert.tsx
+++ b/src/core/Alert/Alert.tsx
@@ -68,10 +68,10 @@ export const Alert = (props: AlertProps) => {
   useTheme();
 
   const iconMap = {
-    negative: <SvgStatusError className='iui-icon' />,
-    informational: <SvgInfoCircular className='iui-icon' />,
-    positive: <SvgStatusSuccess className='iui-icon' />,
-    warning: <SvgStatusWarning className='iui-icon' />,
+    negative: <SvgStatusError className='iui-icon' aria-hidden />,
+    informational: <SvgInfoCircular className='iui-icon' aria-hidden />,
+    positive: <SvgStatusSuccess className='iui-icon' aria-hidden />,
+    warning: <SvgStatusWarning className='iui-icon' aria-hidden />,
   };
 
   return (
@@ -102,7 +102,7 @@ export const Alert = (props: AlertProps) => {
           onClick={onClose}
           aria-label='Close'
         >
-          <SvgCloseSmall aria-hidden='true' />
+          <SvgCloseSmall aria-hidden />
         </IconButton>
       )}
     </div>

--- a/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
@@ -45,13 +45,13 @@ it('should update icon when menu opens or closes', () => {
 
   const {
     container: { firstChild: downArrow },
-  } = render(<SvgCaretDownSmall className='iui-icon' />);
+  } = render(<SvgCaretDownSmall className='iui-icon' aria-hidden />);
   expect(container.querySelector('.iui-icon')).toEqual(downArrow);
 
   button.click();
   const {
     container: { firstChild: upArrow },
-  } = render(<SvgCaretUpSmall className='iui-icon' />);
+  } = render(<SvgCaretUpSmall className='iui-icon' aria-hidden />);
   expect(container.querySelector('.iui-icon')).toEqual(upArrow);
 
   button.click();

--- a/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -63,8 +63,15 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
         className={cx('iui-dropdown', className)}
         size={size}
         styleType={styleType}
-        endIcon={isMenuOpen ? <SvgCaretUpSmall /> : <SvgCaretDownSmall />}
+        endIcon={
+          isMenuOpen ? (
+            <SvgCaretUpSmall aria-hidden />
+          ) : (
+            <SvgCaretDownSmall aria-hidden />
+          )
+        }
         ref={ref}
+        aria-label='Dropdown'
         {...rest}
       >
         {children}

--- a/src/core/Buttons/IconButton/IconButton.tsx
+++ b/src/core/Buttons/IconButton/IconButton.tsx
@@ -54,6 +54,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       >
         {React.cloneElement(children as JSX.Element, {
           className: cx('iui-icon', (children as JSX.Element).props.className),
+          'aria-hidden': true,
         })}
       </button>
     );

--- a/src/core/Buttons/IdeasButton/IdeasButton.tsx
+++ b/src/core/Buttons/IdeasButton/IdeasButton.tsx
@@ -37,7 +37,7 @@ export const IdeasButton = React.forwardRef<
       ref={ref}
       className='iui-idea'
       onClick={onClick}
-      startIcon={<SvgSmileyHappy />}
+      startIcon={<SvgSmileyHappy aria-hidden />}
       {...rest}
     >
       {feedbackLabel}

--- a/src/core/Buttons/SplitButton/SplitButton.test.tsx
+++ b/src/core/Buttons/SplitButton/SplitButton.test.tsx
@@ -69,13 +69,13 @@ it('should update icon when menu opens or closes', () => {
 
   const {
     container: { firstChild: downArrow },
-  } = render(<SvgCaretDownSmall className='iui-icon' />);
+  } = render(<SvgCaretDownSmall className='iui-icon' aria-hidden />);
   expect(container.querySelector('.iui-icon')).toEqual(downArrow);
 
   dropdownButton.click();
   const {
     container: { firstChild: upArrow },
-  } = render(<SvgCaretUpSmall className='iui-icon' />);
+  } = render(<SvgCaretUpSmall className='iui-icon' aria-hidden />);
   expect(container.querySelector('.iui-icon')).toEqual(upArrow);
 
   dropdownButton.click();

--- a/src/core/DatePicker/DatePicker.tsx
+++ b/src/core/DatePicker/DatePicker.tsx
@@ -307,8 +307,9 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
             <IconButton
               styleType='borderless'
               onClick={handleMoveToPreviousMonth}
+              aria-label='Previous month'
             >
-              <SvgChevronLeft aria-hidden={true} />
+              <SvgChevronLeft />
             </IconButton>
             <span aria-live='polite'>
               <span
@@ -319,8 +320,12 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
               </span>
               &nbsp;{displayedYear}
             </span>
-            <IconButton styleType='borderless' onClick={handleMoveToNextMonth}>
-              <SvgChevronRight aria-hidden={true} />
+            <IconButton
+              styleType='borderless'
+              onClick={handleMoveToNextMonth}
+              aria-label='Next month'
+            >
+              <SvgChevronRight />
             </IconButton>
           </div>
           <div className='iui-weekdays'>

--- a/src/core/ExpandableBlock/ExpandableBlock.tsx
+++ b/src/core/ExpandableBlock/ExpandableBlock.tsx
@@ -94,7 +94,7 @@ export const ExpandableBlock = (props: ExpandableBlockProps) => {
         onClick={handleToggle}
         onKeyDown={onKeyDown}
       >
-        <SvgChevronRight className='iui-icon' />
+        <SvgChevronRight className='iui-icon' aria-hidden />
         <div className='iui-title'>{title}</div>
         {caption && <div className='iui-caption'>{caption}</div>}
       </div>

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import cx from 'classnames';
-import SvgCloseSmall from '@itwin/itwinui-icons-react/cjs/icons/CloseSmall';
+import SvgClose from '@itwin/itwinui-icons-react/cjs/icons/Close';
 import { CommonProps } from '../utils/props';
 import { useTheme } from '../utils/hooks/useTheme';
 import '@itwin/itwinui-css/css/modal.css';
@@ -175,8 +175,13 @@ export const Modal = (props: ModalProps) => {
           <div className='iui-title-bar'>
             <div className='iui-title'>{title}</div>
             {isDismissible && (
-              <IconButton size='small' styleType='borderless' onClick={onClose}>
-                <SvgCloseSmall aria-hidden />
+              <IconButton
+                size='small'
+                styleType='borderless'
+                onClick={onClose}
+                aria-label='Close'
+              >
+                <SvgClose aria-hidden />
               </IconButton>
             )}
           </div>

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -181,7 +181,7 @@ export const Modal = (props: ModalProps) => {
                 onClick={onClose}
                 aria-label='Close'
               >
-                <SvgClose aria-hidden />
+                <SvgClose />
               </IconButton>
             )}
           </div>

--- a/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
+++ b/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import Positive from '@itwin/itwinui-icons-react/cjs/icons/Checkmark';
-import Negative from '@itwin/itwinui-icons-react/cjs/icons/Important';
+import Positive from '@itwin/itwinui-icons-react/cjs/icons/CheckmarkSmall';
+import Negative from '@itwin/itwinui-icons-react/cjs/icons/ImportantSmall';
 import cx from 'classnames';
 import React from 'react';
 import { CommonProps } from '../../utils/props';
@@ -67,8 +67,8 @@ export const ProgressRadial = (props: ProgressRadialProps) => {
   useTheme();
 
   const statusMap = {
-    negative: <Negative />,
-    positive: <Positive />,
+    negative: <Negative aria-hidden />,
+    positive: <Positive aria-hidden />,
   };
 
   const fillStyle: React.CSSProperties = {

--- a/src/core/RadioTiles/RadioTile.tsx
+++ b/src/core/RadioTiles/RadioTile.tsx
@@ -61,7 +61,7 @@ export const RadioTile = React.forwardRef<HTMLInputElement, RadioTileProps>(
       <label className={className} style={style}>
         <input type='radio' ref={refs} {...rest} />
         <div className='iui-radio-tile'>
-          <SvgCheckmark className='iui-checkmark' />
+          <SvgCheckmark className='iui-checkmark' aria-hidden />
           {icon &&
             React.cloneElement(icon, {
               className: cx('iui-icon', icon.props.className),

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -290,9 +290,9 @@ export const Table = <
                       <div className='iui-sort'>
                         <div className='iui-icon-wrapper'>
                           {column.isSorted && column.isSortedDesc ? (
-                            <SvgSortUp />
+                            <SvgSortUp className='iui-icon' />
                           ) : (
-                            <SvgSortDown />
+                            <SvgSortDown className='iui-icon' />
                           )}
                         </div>
                       </div>

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -290,9 +290,9 @@ export const Table = <
                       <div className='iui-sort'>
                         <div className='iui-icon-wrapper'>
                           {column.isSorted && column.isSortedDesc ? (
-                            <SvgSortUp className='iui-icon' />
+                            <SvgSortUp className='iui-icon' aria-hidden />
                           ) : (
-                            <SvgSortDown className='iui-icon' />
+                            <SvgSortDown className='iui-icon' aria-hidden />
                           )}
                         </div>
                       </div>

--- a/src/core/Tag/Tag.tsx
+++ b/src/core/Tag/Tag.tsx
@@ -46,7 +46,12 @@ export const Tag = (props: TagProps) => {
     >
       <span className='iui-label'>{children}</span>
       {onRemove && (
-        <IconButton styleType='borderless' size='small' onClick={onRemove}>
+        <IconButton
+          styleType='borderless'
+          size='small'
+          onClick={onRemove}
+          aria-label='Delete tag'
+        >
           <SvgCloseSmall />
         </IconButton>
       )}

--- a/src/core/Tag/Tag.tsx
+++ b/src/core/Tag/Tag.tsx
@@ -52,7 +52,7 @@ export const Tag = (props: TagProps) => {
           onClick={onRemove}
           aria-label='Delete tag'
         >
-          <SvgCloseSmall />
+          <SvgCloseSmall aria-hidden />
         </IconButton>
       )}
     </span>

--- a/src/core/Tile/Tile.tsx
+++ b/src/core/Tile/Tile.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import cx from 'classnames';
 import SvgCheckmark from '@itwin/itwinui-icons-react/cjs/icons/Checkmark';
-import SvgMoreSmall from '@itwin/itwinui-icons-react/cjs/icons/MoreSmall';
+import SvgMore from '@itwin/itwinui-icons-react/cjs/icons/More';
 import SvgNew from '@itwin/itwinui-icons-react/cjs/icons/New';
 import { useTheme } from '../utils/hooks/useTheme';
 import '@itwin/itwinui-css/css/tile.css';
@@ -48,7 +48,7 @@ export type TileProps = {
    *  // or
    *  thumbnail={<UserIcon image={<img src='icon.png' />} />}
    *  // or
-   *  thumbnail={<SvgImodel2 />}
+   *  thumbnail={<SvgImodelHollow />}
    * />
    */
   thumbnail: string | React.ReactNode;
@@ -176,8 +176,10 @@ export const Tile = (props: TileProps) => {
 
       <div className='iui-content'>
         <div className='iui-name'>
-          {isSelected && <SvgCheckmark className='iui-informational' />}
-          {isNew && <SvgNew className='iui-positive' />}
+          {isSelected && (
+            <SvgCheckmark className='iui-informational' aria-hidden />
+          )}
+          {isNew && <SvgNew className='iui-positive' aria-hidden />}
           <span className='iui-name-label'>{name}</span>
         </div>
 
@@ -211,8 +213,9 @@ export const Tile = (props: TileProps) => {
               className={cx('iui-more-options', {
                 'iui-visible': isMenuVisible,
               })}
+              aria-label='More options'
             >
-              <SvgMoreSmall />
+              <SvgMore />
             </IconButton>
           </DropdownMenu>
         )}

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -162,8 +162,13 @@ export const Toast = (props: ToastProps) => {
                 </a>
               )}
               {(type === 'persisting' || hasCloseButton) && (
-                <IconButton size='small' styleType='borderless' onClick={close}>
-                  <SvgCloseSmall aria-hidden />
+                <IconButton
+                  size='small'
+                  styleType='borderless'
+                  onClick={close}
+                  aria-label='Close'
+                >
+                  <SvgCloseSmall />
                 </IconButton>
               )}
             </div>

--- a/src/core/UserIcon/UserIcon.test.tsx
+++ b/src/core/UserIcon/UserIcon.test.tsx
@@ -9,10 +9,10 @@ import { defaultStatusTitles, UserIcon, UserIconStatus } from './UserIcon';
 
 function assertBaseElements(size = 'small', backgroundColor = 'white') {
   const userIconContainer = screen.getByTitle('Terry Rivers');
-  expect(userIconContainer.className).toEqual(`iui-user-icons-${size}`);
+  expect(userIconContainer.className).toEqual(`iui-user-icon iui-${size}`);
 
   const abbreviation = screen.getByText('TR');
-  expect(abbreviation.className).toEqual('iui-user-icons-initials');
+  expect(abbreviation.className).toEqual('iui-initials');
   expect(abbreviation.style.backgroundColor).toEqual(backgroundColor);
 }
 
@@ -41,7 +41,7 @@ it.each(['', 'online', 'busy', 'away', 'offline'] as Array<UserIconStatus>)(
     );
     assertBaseElements();
     const statusContainer = container.querySelector(
-      '.iui-user-icons-status',
+      '.iui-status',
     ) as HTMLElement;
     if (!status) {
       expect(statusContainer).toBeFalsy();
@@ -68,9 +68,7 @@ it('should render with translated statuses', () => {
     />,
   );
 
-  const statusContainer = container.querySelector(
-    '.iui-user-icons-status',
-  ) as HTMLElement;
+  const statusContainer = container.querySelector('.iui-status') as HTMLElement;
   expect(statusContainer.getAttribute('title')).toEqual('test-offline');
 });
 
@@ -91,8 +89,8 @@ it('renders with image', () => {
   );
 
   const userIconContainer = screen.getByTitle('Terry Rivers');
-  expect(userIconContainer.className).toEqual('iui-user-icons-small');
-  const abbreviation = container.querySelector('.iui-user-icons-initials');
+  expect(userIconContainer.className).toEqual('iui-user-icon iui-small');
+  const abbreviation = container.querySelector('.iui-initials');
   expect(abbreviation).toBeFalsy();
   const img = container.querySelector('img');
   expect(img).toBeTruthy();

--- a/src/core/UserIcon/UserIcon.test.tsx
+++ b/src/core/UserIcon/UserIcon.test.tsx
@@ -9,7 +9,9 @@ import { defaultStatusTitles, UserIcon, UserIconStatus } from './UserIcon';
 
 function assertBaseElements(size = 'small', backgroundColor = 'white') {
   const userIconContainer = screen.getByTitle('Terry Rivers');
-  expect(userIconContainer.className).toEqual(`iui-user-icon iui-${size}`);
+  expect(userIconContainer.className).toEqual(
+    `iui-user-icon${size !== 'medium' ? ` iui-${size}` : ''}`,
+  );
 
   const abbreviation = screen.getByText('TR');
   expect(abbreviation.className).toEqual('iui-initials');

--- a/src/core/UserIcon/UserIcon.tsx
+++ b/src/core/UserIcon/UserIcon.tsx
@@ -89,9 +89,9 @@ export const UserIcon = (props: UserIconProps) => {
   const statusTitles = { ...defaultStatusTitles, ...translatedStatusTitles };
 
   const iconMap: { [key in UserIconStatus]: JSX.Element } = {
-    away: <SvgAway className='iui-status-symbol' />,
-    offline: <SvgCloseSmall className='iui-status-symbol' />,
-    online: <SvgCheckmark className='iui-status-symbol' />,
+    away: <SvgAway className='iui-status-symbol' aria-hidden />,
+    offline: <SvgCloseSmall className='iui-status-symbol' aria-hidden />,
+    online: <SvgCheckmark className='iui-status-symbol' aria-hidden />,
     busy: <></>,
   };
 
@@ -114,6 +114,7 @@ export const UserIcon = (props: UserIconProps) => {
           className={cx('iui-status', {
             [`iui-${status}`]: !!status,
           })}
+          aria-label={statusTitles[status]}
         >
           {iconMap[status]}
         </span>

--- a/src/core/UserIcon/UserIcon.tsx
+++ b/src/core/UserIcon/UserIcon.tsx
@@ -97,7 +97,11 @@ export const UserIcon = (props: UserIconProps) => {
 
   return (
     <span
-      className={cx(`iui-user-icon iui-${size}`, className)}
+      className={cx(
+        'iui-user-icon',
+        { [`iui-${size}`]: size !== 'medium' },
+        className,
+      )}
       title={title}
       style={style}
       {...rest}

--- a/src/core/UserIcon/UserIcon.tsx
+++ b/src/core/UserIcon/UserIcon.tsx
@@ -89,34 +89,34 @@ export const UserIcon = (props: UserIconProps) => {
   const statusTitles = { ...defaultStatusTitles, ...translatedStatusTitles };
 
   const iconMap: { [key in UserIconStatus]: JSX.Element } = {
-    away: <SvgAway className='iui-user-icons-status-symbol' />,
-    offline: <SvgCloseSmall className='iui-user-icons-status-symbol' />,
-    online: <SvgCheckmark className='iui-user-icons-status-symbol' />,
+    away: <SvgAway className='iui-status-symbol' />,
+    offline: <SvgCloseSmall className='iui-status-symbol' />,
+    online: <SvgCheckmark className='iui-status-symbol' />,
     busy: <></>,
   };
 
   return (
     <span
-      className={cx(`iui-user-icons-${size}`, className)}
+      className={cx(`iui-user-icon iui-${size}`, className)}
       title={title}
       style={style}
       {...rest}
     >
+      {image ?? (
+        <abbr className='iui-initials' style={{ backgroundColor }}>
+          {abbreviation?.substring(0, 2)}
+        </abbr>
+      )}
+      <span className='iui-stroke' />
       {status && (
         <span
           title={statusTitles[status]}
-          className={cx('iui-user-icons-status', {
+          className={cx('iui-status', {
             [`iui-${status}`]: !!status,
           })}
         >
           {iconMap[status]}
         </span>
-      )}
-      <span className='iui-user-icons-stroke' />
-      {image ?? (
-        <abbr className='iui-user-icons-initials' style={{ backgroundColor }}>
-          {abbreviation?.substring(0, 2)}
-        </abbr>
       )}
     </span>
   );

--- a/src/core/utils/common.tsx
+++ b/src/core/utils/common.tsx
@@ -10,9 +10,9 @@ import React from 'react';
 export const StatusIconMap: {
   [key in 'negative' | 'positive' | 'warning']: JSX.Element;
 } = {
-  negative: <SvgStatusError />,
-  positive: <SvgStatusSuccess />,
-  warning: <SvgStatusWarning />,
+  negative: <SvgStatusError aria-hidden />,
+  positive: <SvgStatusSuccess aria-hidden />,
+  warning: <SvgStatusWarning aria-hidden />,
 };
 
 const USER_COLORS = [

--- a/stories/core/HorizontalTabs.stories.tsx
+++ b/stories/core/HorizontalTabs.stories.tsx
@@ -47,14 +47,9 @@ BorderlessTabs.args = {
 };
 
 export const PillTabs = Template.bind({});
-
-const style: React.CSSProperties = {
-  width: 16,
-  height: 16,
-};
 PillTabs.args = {
   labels: [...new Array(3)].map((_, index) => (
-    <SvgStar key={index} style={style} />
+    <SvgStar key={index} aria-hidden />
   )),
   type: 'pill',
 };

--- a/stories/core/Tile.stories.tsx
+++ b/stories/core/Tile.stories.tsx
@@ -16,7 +16,7 @@ import {
   TileProps,
 } from '../../src/core';
 import SvgFolder from '@itwin/itwinui-icons-react/cjs/icons/Folder';
-import SvgPlaceholder from '@itwin/itwinui-icons-react/cjs/icons/Placeholder';
+import SvgImodelHollow from '@itwin/itwinui-icons-react/cjs/icons/ImodelHollow';
 import SvgInfo from '@itwin/itwinui-icons-react/cjs/icons/Info';
 import SvgStar from '@itwin/itwinui-icons-react/cjs/icons/Star';
 import SvgTag from '@itwin/itwinui-icons-react/cjs/icons/Tag';
@@ -167,7 +167,7 @@ Condensed.args = {
   description: undefined,
   metadata: undefined,
   badge: undefined,
-  thumbnail: <SvgPlaceholder />,
+  thumbnail: <SvgImodelHollow />,
 };
 
 export const UserIcon: Story<TileProps> = (props) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,20 +1209,20 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.11.0.tgz#fef1c8357186c17749a36d8e28c1b19c5a222887"
-  integrity sha512-r92v6sLsYXD3JaRlg4wrgDOJQmjjA6AD7T3mm72rNkx0QRDu8nEPuWPZWRxeg256F/bfTVbHz+z2dynGTo5KNQ==
+"@itwin/itwinui-css@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.12.0.tgz#c58b19a75d72a98da69db3d06dc226d9f44dafe0"
+  integrity sha512-YdY5WFsi04a9E8rEiDTk6dhYtwpy3x3tMD6DyVH7N5M3alAaBm6tL3vY5/r2MJkIz/zIZPdMU0IjPIMlNN7aQQ==
 
-"@itwin/itwinui-icons-react@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-0.1.0.tgz#812bf14c090d7c5a412e9a678781b5a793966ca9"
-  integrity sha512-zD11tk6ze8ObJD30l5TOSjQq7giNOwqqLNSqATWSjyiuYnnNlxm80ApKXFfzo+j3hnLg4mQvwhzDPyyMIYzHEw==
+"@itwin/itwinui-icons-react@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.1.0.tgz#bb270ba11c8b0443c62b2e6cc1fb17974d8494e9"
+  integrity sha512-Ir1lZE7sJyAsHnmTdH3B3QCejRvi7i6EhuumbCoKV0UkXVmVO0QDsldEuBSGhkHXLsHmDTRyfYOnyFZODfL42Q==
 
-"@itwin/itwinui-illustrations-react@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-0.1.0.tgz#f440c70ae83d22a67b47d209ddf8c5695d07563d"
-  integrity sha512-mX09el9b0/xB0obzEV8mitFK7J2D5PvnmxCNedxOlzVCl+jNopcOHFzxBrvzkPv1vgjCAhmQOY8tMr8wT+FUxw==
+"@itwin/itwinui-illustrations-react@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-1.0.0.tgz#1289701cd3c4a171924616ae0a55507566b209e3"
+  integrity sha512-ROArH2yaMsXHOd213fBG/vektZe4uAwIzYKhjLobc2YnCHB4PfAgkYjysgqpiWUxtcB/lGenr70doL8CqyxxDg==
 
 "@jest/console@^26.6.2":
   version "26.6.2"


### PR DESCRIPTION
Updated @itwin packages:
- itwinui-css: 0.11.0 → 0.12.0
- itwinui-icons-react: 0.1.0 → 1.1.0
- itwinui-illustrations-react: 0.1.0 → 1.0.0

Changes made to reflect the new packages:
- Updated `UserIcon` classes and dom structure.
- Added `aria-hidden` and `aria-label` attributes where applicable.
- Updated `Modal` and `Tile` to use correct icons.
- Added `iui-icon` and `aria-hidden` to `Table` sort icon (will need to do the same for filter).
- Removed size from `HorizontalTabs` story (pill).