### PR TITLE
Fix test report action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,10 @@ jobs:
       - run: yarn test --coverage
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v1.16
         if: always()
         with:
           files: 'coverage/junit.xml'
-          comment_on_pr: false
+          comment_mode: off
           check_name: 'Test results'
           fail_on: 'nothing'


### PR DESCRIPTION
In publish-unit-test-result-action, the `comment_on_pr` option does not work anymore, so replaced with `comment_mode`. 
Also targeting 1.16 specifically to avoid future breaking changes like that.

See https://github.com/EnricoMi/publish-unit-test-result-action/releases