### PR TITLE
Improve overview story logic for hiding addons panel

### DIFF
--- a/stories/intro/Overview.stories.tsx
+++ b/stories/intro/Overview.stories.tsx
@@ -21,6 +21,7 @@ export default {
     options: { showPanel: false },
     controls: { disable: true },
     actions: { disable: true },
+    storysource: { disable: true },
   },
 } as Meta;
 
@@ -30,18 +31,23 @@ export const Overview: Story = () => {
   );
 
   React.useEffect(() => {
-    const hideAddonsButton = parent.document.querySelector(
-      'button[title="Hide addons [A]"]',
+    const shortcutsButton = parent.document.querySelector(
+      'button[title="Shortcuts"]',
     ) as HTMLButtonElement;
+    shortcutsButton?.click();
 
-    const isPanelOpen = !!parent.document.querySelector(
-      '#storybook-preview-wrapper',
-    )?.parentElement?.parentElement?.style.height;
+    setTimeout(() => {
+      const addonsToggle = parent.document.querySelector('a#A') as HTMLElement;
+      const checkmark = addonsToggle?.firstElementChild?.firstElementChild;
 
-    if (isPanelOpen) {
-      hideAddonsButton.click();
-    }
-  });
+      // Panel is open if checkmark is an svg
+      if (checkmark?.tagName === 'svg') {
+        addonsToggle?.click();
+      } else {
+        shortcutsButton?.click();
+      }
+    });
+  }, []);
 
   React.useEffect(() => {
     const listener = (isDark: boolean) => setIsDarkTheme(isDark);
@@ -91,7 +97,7 @@ export const Overview: Story = () => {
           },
           img: {
             component: (args) =>
-              args.src.includes('iTwinUI_logo') ? (
+              args.src.includes('iTwinUI-logo') ? (
                 <img
                   src={isDarkTheme ? itwinImageDark : itwinImage}
                   width={167}


### PR DESCRIPTION
Changed approach for hiding addons panel after noticing that `'button[title="Hide addons [A]"]'` selector was returning null, and `isPanelOpen` was also broken because `style` was not being set at the time of checking.

The new way involves opening the shortcuts menu (because the options inside are not part of the default DOM structure anymore) and checking if this svg is present (and clicking the button to hide if present):
![image](https://user-images.githubusercontent.com/9084735/118177655-f9454c00-b400-11eb-8e5b-d4af99e4d74c.png)

Also was able to disable Storysource addon, so opening panel will now show this:
![image](https://user-images.githubusercontent.com/9084735/118177782-25f96380-b401-11eb-9bf8-ada6e0823f96.png)

Also fixed logo theming.
