### PR TITLE
Add useWindowSize hook to DropdownButton

### DIFF
--- a/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -11,6 +11,7 @@ import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
 
 import { useTheme } from '../../utils/hooks/useTheme';
 import '@itwin/itwinui-css/css/button.css';
+import { useWindowSize } from '../../utils/hooks/useWindowSize';
 
 export type DropdownButtonProps = {
   /**
@@ -43,6 +44,8 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
 
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 
+  const windowSize = useWindowSize(500);
+
   const [menuWidth, setMenuWidth] = React.useState(0);
   const ref = React.useRef<HTMLButtonElement>(null);
 
@@ -50,7 +53,7 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
     if (ref.current) {
       setMenuWidth(ref.current.offsetWidth);
     }
-  }, [children, size, styleType]);
+  }, [children, size, styleType, windowSize]);
 
   return (
     <DropdownMenu

--- a/src/core/utils/hooks/useWindowSize.tsx
+++ b/src/core/utils/hooks/useWindowSize.tsx
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from 'react';
+
+/**
+ * Hook that returns window dimensions updated through the `resize` event.
+ * @param delay maximum ms to debounce the update by
+ * @returns state object containing height and width of the window
+ */
+export const useWindowSize = (delay = 0) => {
+  const [size, setSize] = React.useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  });
+
+  React.useEffect(() => {
+    const updateSize = () => {
+      setSize({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      });
+    };
+    const listener = delay ? debounce(updateSize, delay) : updateSize;
+    window.addEventListener('resize', listener);
+    return () => window.removeEventListener('resize', listener);
+  });
+
+  return size;
+};
+
+/** Returns a debounced fn that waits delayed by the provided ms */
+const debounce = <F extends (...args: never[]) => unknown>(
+  fn: F,
+  ms: number,
+) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  return function (this: never, ...args: never[]) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+  } as F;
+};


### PR DESCRIPTION
Hook listens to window `resize` event and updates size. Used in `DropdownButton` to update menu width when window gets resized.

## Checklist

- [ ] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Add an entry to the changelog for any new components and changes
- [ ] Add screenshots of the key elements of the component below
- [x] Add any additional comments below describing the features you've implemented

## Additional Comments

After #73, it became obvious that the header dropdowns were not being updated on resizing window so this PR is mainly intended to fix that.
