### PR TITLE
Move Select dropdown inside `iui-select` div

### DIFF
--- a/src/core/Select/Select.tsx
+++ b/src/core/Select/Select.tsx
@@ -254,24 +254,29 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
   }, [options, value]);
 
   return (
-    <DropdownMenu
-      menuItems={menuItems}
-      placement='bottom-start'
-      className={menuClassName}
-      style={{ minWidth, maxHeight: `300px`, overflowY: 'auto', ...menuStyle }}
-      role='listbox'
-      onShow={onShowHandler}
-      onHide={onHideHandler}
-      visible={isOpen}
-      disabled={disabled}
-      {...popoverProps}
+    <div
+      className={cx('iui-select', className)}
+      aria-expanded={isOpen}
+      aria-haspopup='listbox'
+      style={style}
+      {...rest}
     >
-      <div
-        className={cx('iui-select', className)}
-        aria-expanded={isOpen}
-        aria-haspopup='listbox'
-        style={style}
-        {...rest}
+      <DropdownMenu
+        menuItems={menuItems}
+        placement='bottom-start'
+        className={menuClassName}
+        style={{
+          minWidth,
+          maxHeight: `300px`,
+          overflowY: 'auto',
+          ...menuStyle,
+        }}
+        role='listbox'
+        onShow={onShowHandler}
+        onHide={onHideHandler}
+        visible={isOpen}
+        disabled={disabled}
+        {...popoverProps}
       >
         <div
           ref={selectRef}
@@ -298,8 +303,8 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
             </>
           )}
         </div>
-      </div>
-    </DropdownMenu>
+      </DropdownMenu>
+    </div>
   );
 };
 


### PR DESCRIPTION
The `DropdownMenu` tippy has been moved inside the `div.iui-select` instead of staying out somewhere. This should make it easier to find the menu for testing purposes.

## Checklist

- [ ] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Add an entry to the changelog for any new components and changes
- [ ] Add screenshots of the key elements of the component below
- [ ] Add any additional comments below describing the features you've implemented
