### PR TITLE
Update to itwinui-css 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 - **Added number range filter to `Table`.** Use `tableFilters.NumberRangeFilter`.
 - **Updated `ThemeProvider` component and `useTheme` hook to allow specification of ownerDocument**. This provides support for theme in popup browser windows.
+- **Added new sizes to `ProgressRadial`.** The `size` prop can now accept 'x-small' and 'large' as values.
+
+### Fixes
+
+- **Fixed `Wizard` resizing and `UserIcon` size issues** through base CSS package.
 
 ## [1.5.0]
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "audit:ci": "audit-ci --moderate --report-type=full --allowlist=postcss"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "^0.16.0",
+    "@itwin/itwinui-css": "^0.17.0",
     "@itwin/itwinui-icons-react": "^1.1.1",
     "@itwin/itwinui-illustrations-react": "^1.0.1",
     "@tippyjs/react": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "audit:ci": "audit-ci --moderate --report-type=full --allowlist=postcss"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "^0.17.0",
+    "@itwin/itwinui-css": "^0.17.1",
     "@itwin/itwinui-icons-react": "^1.1.1",
     "@itwin/itwinui-illustrations-react": "^1.0.1",
     "@tippyjs/react": "^4.2.5",

--- a/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.test.tsx
+++ b/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.test.tsx
@@ -96,3 +96,15 @@ it('renders determinate small  ProgressRadial', () => {
   const spinnerFill = container.querySelector('.iui-fill') as SVGCircleElement;
   expect(spinnerFill.style.strokeDashoffset).toBe('44');
 });
+
+it('should render all sizes of ProgressRadial', () => {
+  const sizes = ['small', 'x-small', 'large'] as const;
+
+  sizes.forEach((size) => {
+    const { container } = render(<ProgressRadial size={size} />);
+    const spinner = container.querySelector(
+      `.iui-progress-indicator-radial.iui-determinate.iui-${size}`,
+    ) as HTMLElement;
+    expect(spinner).toBeTruthy();
+  });
+});

--- a/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
+++ b/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
@@ -26,10 +26,10 @@ export type ProgressRadialProps = {
    */
   status?: 'positive' | 'negative';
   /**
-   * Size of the Progress.
+   * Size of the progress indicator. If undefined or '', medium size will be used.
    * @default ''
    */
-  size?: '' | 'small';
+  size?: '' | 'x-small' | 'small' | 'large';
   /**
    * Content shown inside progress indicator.
    */
@@ -84,7 +84,7 @@ export const ProgressRadial = (props: ProgressRadialProps) => {
       className={cx('iui-progress-indicator-radial', {
         'iui-determinate': !indeterminate,
         'iui-indeterminate': indeterminate,
-        'iui-small': size === 'small',
+        [`iui-${size}`]: !!size,
         [`iui-${status}`]: !!status,
         className,
       })}

--- a/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
+++ b/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
@@ -26,7 +26,7 @@ export type ProgressRadialProps = {
    */
   status?: 'positive' | 'negative';
   /**
-   * Size of the progress indicator. If undefined or '', medium size will be used.
+   * Size of the progress indicator. Defaults to medium size.
    * @default ''
    */
   size?: '' | 'x-small' | 'small' | 'large';

--- a/src/core/Wizard/Step.test.tsx
+++ b/src/core/Wizard/Step.test.tsx
@@ -318,3 +318,33 @@ describe('Wizard step (workflow)', () => {
     expect(container.querySelector('.iui-wizards-step-track-main')).toBeNull();
   });
 });
+
+it('should set dynamic percentage width based on total steps', () => {
+  const { container: container1 } = render(
+    <Step
+      title='Mock step'
+      index={1}
+      currentStepNumber={0}
+      totalSteps={4}
+      type={'default'}
+    />,
+  );
+
+  const step1 = container1.querySelector('.iui-wizards-step') as HTMLElement;
+  expect(step1).toBeTruthy();
+  expect(step1.style.width).toEqual('25%');
+
+  const { container: container2 } = render(
+    <Step
+      title='Mock step'
+      index={1}
+      currentStepNumber={1}
+      totalSteps={8}
+      type={'default'}
+    />,
+  );
+
+  const step2 = container2.querySelector('.iui-wizards-step') as HTMLElement;
+  expect(step2).toBeTruthy();
+  expect(step2.style.width).toEqual('12.5%');
+});

--- a/src/core/Wizard/Step.test.tsx
+++ b/src/core/Wizard/Step.test.tsx
@@ -319,7 +319,7 @@ describe('Wizard step (workflow)', () => {
   });
 });
 
-it('should set dynamic percentage width based on total steps', () => {
+it('should set dynamic inline width based on total steps', () => {
   const { container: container1 } = render(
     <Step
       title='Mock step'
@@ -347,4 +347,34 @@ it('should set dynamic percentage width based on total steps', () => {
   const step2 = container2.querySelector('.iui-wizards-step') as HTMLElement;
   expect(step2).toBeTruthy();
   expect(step2.style.width).toEqual('12.5%');
+});
+
+it('should not set dynamic inline width for long and workflow wizard types', () => {
+  const { container: container1 } = render(
+    <Step
+      title='Mock step'
+      index={1}
+      currentStepNumber={0}
+      totalSteps={4}
+      type={'long'}
+    />,
+  );
+
+  const step1 = container1.querySelector('.iui-wizards-step') as HTMLElement;
+  expect(step1).toBeTruthy();
+  expect(step1.style.width).toBeFalsy(); // not 25%
+
+  const { container: container2 } = render(
+    <Step
+      title='Mock step'
+      index={1}
+      currentStepNumber={1}
+      totalSteps={8}
+      type={'workflow'}
+    />,
+  );
+
+  const step2 = container2.querySelector('.iui-wizards-step') as HTMLElement;
+  expect(step2).toBeTruthy();
+  expect(step2.style.width).toBeFalsy(); // not 12.5%
 });

--- a/src/core/Wizard/Step.test.tsx
+++ b/src/core/Wizard/Step.test.tsx
@@ -378,3 +378,24 @@ it('should not set dynamic inline width for long and workflow wizard types', () 
   expect(step2).toBeTruthy();
   expect(step2.style.width).toBeFalsy(); // not 12.5%
 });
+
+it('should add className and style props correctly', () => {
+  const { container } = render(
+    <Step
+      title='Mock step'
+      index={1}
+      currentStepNumber={0}
+      totalSteps={4}
+      type={'default'}
+      className='custom-class'
+      style={{ width: 50, color: 'red' }}
+    />,
+  );
+
+  const step = container.querySelector(
+    '.iui-wizards-step.custom-class',
+  ) as HTMLElement;
+  expect(step).toBeTruthy();
+  expect(step.style.width).toEqual('50px');
+  expect(step.style.color).toEqual('red');
+});

--- a/src/core/Wizard/Step.test.tsx
+++ b/src/core/Wizard/Step.test.tsx
@@ -37,10 +37,8 @@ describe('Wizard step (long)', () => {
     // Correct title
     const title = getByText('First step');
     expect(title.className).toBe('iui-wizards-step-title');
-    // Track after
-    expect(
-      container.querySelector('.iui-wizards-step-track-after'),
-    ).toBeTruthy();
+    // No track after
+    expect(container.querySelector('.iui-wizards-step-track-after')).toBeNull();
     // Circle
     const circle = getByText('1');
     expect(circle.className).toBe('iui-wizards-step-circle');
@@ -81,10 +79,8 @@ describe('Wizard step (long)', () => {
     // Correct title
     const title = getByText('First step');
     expect(title.className).toBe('iui-wizards-step-title');
-    // Track after
-    expect(
-      container.querySelector('.iui-wizards-step-track-after'),
-    ).toBeTruthy();
+    // No track after
+    expect(container.querySelector('.iui-wizards-step-track-after')).toBeNull();
     // Circle
     const circle = getByText('1');
     expect(circle.className).toBe('iui-wizards-step-circle');
@@ -119,17 +115,15 @@ describe('Wizard step (long)', () => {
     expect(stepContainer.className).not.toContain('iui-clickable');
     stepContainer.click();
     expect(mockedClick).not.toHaveBeenCalled();
-    // Track before
+    // No track before
     expect(
       container.querySelector('.iui-wizards-step-track-before'),
-    ).toBeTruthy();
+    ).toBeNull();
     // Correct title
     const title = getByText('Second step');
     expect(title.className).toBe('iui-wizards-step-title');
-    // Track after
-    expect(
-      container.querySelector('.iui-wizards-step-track-after'),
-    ).toBeTruthy();
+    // No track after
+    expect(container.querySelector('.iui-wizards-step-track-after')).toBeNull();
     // Circle
     const circle = getByText('2');
     expect(circle.className).toBe('iui-wizards-step-circle');
@@ -154,10 +148,10 @@ describe('Wizard step (long)', () => {
 
     // Renders as active
     expect(container.querySelector('.iui-wizards-step-current')).toBeTruthy();
-    // Track before
+    // No track before
     expect(
       container.querySelector('.iui-wizards-step-track-before'),
-    ).toBeTruthy();
+    ).toBeNull();
     // Correct title
     const title = getByText('Last step');
     expect(title.className).toBe('iui-wizards-step-title');
@@ -187,16 +181,14 @@ describe('Wizard step (workflow)', () => {
 
     // Renders as active
     expect(container.querySelector('.iui-wizards-step-current')).toBeTruthy();
-    // There is no track before
+    // No track before
     expect(
       container.querySelector('.iui-wizards-step-track-before'),
     ).toBeNull();
     // No title
     expect(container.querySelector('iui-wizards-step-title')).toBeNull();
-    // Track after
-    expect(
-      container.querySelector('.iui-wizards-step-track-after'),
-    ).toBeTruthy();
+    // No track after
+    expect(container.querySelector('.iui-wizards-step-track-after')).toBeNull();
     // Circle
     const circle = container.querySelector(
       '.iui-wizards-step-circle',
@@ -224,16 +216,14 @@ describe('Wizard step (workflow)', () => {
 
     // Renders as completed
     expect(container.querySelector('.iui-wizards-step-completed')).toBeTruthy();
-    // Track before
+    // No track before
     expect(
       container.querySelector('.iui-wizards-step-track-before'),
     ).toBeNull();
     // No title
     expect(container.querySelector('iui-wizards-step-title')).toBeNull();
-    // Track after
-    expect(
-      container.querySelector('.iui-wizards-step-track-after'),
-    ).toBeTruthy();
+    // No track after
+    expect(container.querySelector('.iui-wizards-step-track-after')).toBeNull();
     // Circle
     const circle = container.querySelector(
       '.iui-wizards-step-circle',
@@ -263,16 +253,14 @@ describe('Wizard step (workflow)', () => {
 
     // Renders step
     expect(container.querySelector('.iui-wizards-step')).toBeTruthy();
-    // Track before
+    // No track before
     expect(
       container.querySelector('.iui-wizards-step-track-before'),
-    ).toBeTruthy();
+    ).toBeNull();
     // No title
     expect(container.querySelector('iui-wizards-step-title')).toBeNull();
-    // Track after
-    expect(
-      container.querySelector('.iui-wizards-step-track-after'),
-    ).toBeTruthy();
+    // No track after
+    expect(container.querySelector('.iui-wizards-step-track-after')).toBeNull();
     // Circle
     const circle = container.querySelector(
       '.iui-wizards-step-circle',
@@ -300,10 +288,10 @@ describe('Wizard step (workflow)', () => {
 
     // Renders as active
     expect(container.querySelector('.iui-wizards-step-current')).toBeTruthy();
-    // Track before
+    // No track before
     expect(
       container.querySelector('.iui-wizards-step-track-before'),
-    ).toBeTruthy();
+    ).toBeNull();
     // No title
     expect(container.querySelector('iui-wizards-step-title')).toBeNull();
     // Track after

--- a/src/core/Wizard/Step.tsx
+++ b/src/core/Wizard/Step.tsx
@@ -5,6 +5,7 @@
 import cx from 'classnames';
 import React from 'react';
 import { Tooltip } from '../Tooltip';
+import { StylingProps } from '../utils/props';
 import { WizardType } from './Wizard';
 
 export type StepProps = {
@@ -36,7 +37,7 @@ export type StepProps = {
    * A tooltip giving detailed description to this step.
    */
   description?: string;
-};
+} & StylingProps;
 
 export const Step = (props: StepProps) => {
   const {
@@ -47,6 +48,8 @@ export const Step = (props: StepProps) => {
     type,
     onClick,
     description,
+    className,
+    style,
     ...rest
   } = props;
 
@@ -62,12 +65,19 @@ export const Step = (props: StepProps) => {
 
   const stepShape = (
     <span
-      className={cx('iui-wizards-step', {
-        'iui-wizards-step-completed': isPast,
-        'iui-wizards-step-current': isActive,
-        'iui-clickable': !!onClick && isPast,
-      })}
-      style={{ width: `${100 / totalSteps}%` }}
+      className={cx(
+        'iui-wizards-step',
+        {
+          'iui-wizards-step-completed': isPast,
+          'iui-wizards-step-current': isActive,
+          'iui-clickable': !!onClick && isPast,
+        },
+        className,
+      )}
+      style={{
+        width: type === 'default' ? `${100 / totalSteps}%` : undefined,
+        ...style,
+      }}
       onClick={onCompletedClick}
       {...rest}
     >

--- a/src/core/Wizard/Step.tsx
+++ b/src/core/Wizard/Step.tsx
@@ -81,7 +81,7 @@ export const Step = (props: StepProps) => {
       onClick={onCompletedClick}
       {...rest}
     >
-      {index !== 0 && (
+      {index !== 0 && type === 'default' && (
         <span
           className={cx(
             'iui-wizards-step-track',
@@ -93,7 +93,7 @@ export const Step = (props: StepProps) => {
       {type !== 'workflow' && (
         <span className='iui-wizards-step-title'>{title}</span>
       )}
-      {!isLast && (
+      {!isLast && type === 'default' && (
         <span
           className={cx(
             'iui-wizards-step-track',

--- a/src/core/Wizard/Step.tsx
+++ b/src/core/Wizard/Step.tsx
@@ -67,6 +67,7 @@ export const Step = (props: StepProps) => {
         'iui-wizards-step-current': isActive,
         'iui-clickable': !!onClick && isPast,
       })}
+      style={{ width: `${100 / totalSteps}%` }}
       onClick={onCompletedClick}
       {...rest}
     >
@@ -80,12 +81,7 @@ export const Step = (props: StepProps) => {
       )}
 
       {type !== 'workflow' && (
-        <span
-          className='iui-wizards-step-title'
-          style={{ width: `${100 / totalSteps}vw` }}
-        >
-          {title}
-        </span>
+        <span className='iui-wizards-step-title'>{title}</span>
       )}
       {!isLast && (
         <span

--- a/src/core/Wizard/Step.tsx
+++ b/src/core/Wizard/Step.tsx
@@ -80,7 +80,12 @@ export const Step = (props: StepProps) => {
       )}
 
       {type !== 'workflow' && (
-        <span className='iui-wizards-step-title'>{title}</span>
+        <span
+          className='iui-wizards-step-title'
+          style={{ width: `${100 / totalSteps}vw` }}
+        >
+          {title}
+        </span>
       )}
       {!isLast && (
         <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,15 +1214,15 @@
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.17.0.tgz#099cdf00bc8e7d89dba0e60be11dbfea30b4a8ff"
   integrity sha512-I0mwZf0Rf/JIZe5Cxojbc6XPHfnv/2QhaNYkgHlEI6IghVMkjC7BL0Wt+5oRIE7nwUm5Q0VGV3Wl9A/G7Y7tqw==
 
-"@itwin/itwinui-icons-react@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.1.1.tgz#f31e89588eb519f8f6d39032ac1ce359f2185d99"
-  integrity sha512-+Z43/PYkdfeLzo/2+NevRe9q1Ew1w1BQfsLr4gU60ZHhWi57gaik/b66ZNI6ZKb9IX0YG7xgPDUDUgl+rFTPVg==
+"@itwin/itwinui-icons-react@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.1.3.tgz#11cab736a37b66d9e0cec89de9593b55da9de5d2"
+  integrity sha512-CNTjNvbuscb8nGOpu9PGRQc5ciYlwcKVOSxs8HYBa9xdf2QKl3iPuj3+B85tsNYGkZJGa6DMli1KAhr2w27aSw==
 
-"@itwin/itwinui-illustrations-react@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-1.0.1.tgz#455c6910ed07429472a80d11581a9fe9cf3ff496"
-  integrity sha512-Z/qgZodNmko7sq8xo7QQ10di7B8gcszaGo+UCsfFsNaVykcT1IjIbI4a2ia50nio2h8Af7dMiAcXgqMs+g3Uzw==
+"@itwin/itwinui-illustrations-react@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-1.0.2.tgz#4b1f04a1c331937ec501dde3a25275bb2d995cec"
+  integrity sha512-sgBmBBOGOLNPuT/G700iQqlPB/QRBBWczSkVZJ7mpCZaktMfJxX2SH1NhUUpJ4emf20dsLEeAo62Gz7ek7DMkA==
 
 "@jest/console@^26.6.2":
   version "26.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,12 +1214,12 @@
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.17.0.tgz#099cdf00bc8e7d89dba0e60be11dbfea30b4a8ff"
   integrity sha512-I0mwZf0Rf/JIZe5Cxojbc6XPHfnv/2QhaNYkgHlEI6IghVMkjC7BL0Wt+5oRIE7nwUm5Q0VGV3Wl9A/G7Y7tqw==
 
-"@itwin/itwinui-icons-react@^1.1.3":
+"@itwin/itwinui-icons-react@^1.1.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.1.3.tgz#11cab736a37b66d9e0cec89de9593b55da9de5d2"
   integrity sha512-CNTjNvbuscb8nGOpu9PGRQc5ciYlwcKVOSxs8HYBa9xdf2QKl3iPuj3+B85tsNYGkZJGa6DMli1KAhr2w27aSw==
 
-"@itwin/itwinui-illustrations-react@^1.0.2":
+"@itwin/itwinui-illustrations-react@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-1.0.2.tgz#4b1f04a1c331937ec501dde3a25275bb2d995cec"
   integrity sha512-sgBmBBOGOLNPuT/G700iQqlPB/QRBBWczSkVZJ7mpCZaktMfJxX2SH1NhUUpJ4emf20dsLEeAo62Gz7ek7DMkA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,10 +1209,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.17.0.tgz#099cdf00bc8e7d89dba0e60be11dbfea30b4a8ff"
-  integrity sha512-I0mwZf0Rf/JIZe5Cxojbc6XPHfnv/2QhaNYkgHlEI6IghVMkjC7BL0Wt+5oRIE7nwUm5Q0VGV3Wl9A/G7Y7tqw==
+"@itwin/itwinui-css@^0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.17.1.tgz#c6a3ab7bc440e38d4db517f489929d84f5db8a6c"
+  integrity sha512-7yW8TeHt08i1rmHAXkWsJ4MjYyH0G6KpziqXDCs7jeBXQuQnSeK/baZwMtPm6/2Z9fRnebWoHpiZhJCqi9a2UQ==
 
 "@itwin/itwinui-icons-react@^1.1.1":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,10 +1209,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.16.0.tgz#b05c316185fc0504a457e3b80733deb6efec9f68"
-  integrity sha512-W5DQs+/Dgv6FiUdZTLjnVHfcpK0+nPvBbSN6GiuubE8Y83d5JOelDAmSz0HtrmFVTjNcKUZf9+KXt7b8hg2JFQ==
+"@itwin/itwinui-css@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.17.0.tgz#099cdf00bc8e7d89dba0e60be11dbfea30b4a8ff"
+  integrity sha512-I0mwZf0Rf/JIZe5Cxojbc6XPHfnv/2QhaNYkgHlEI6IghVMkjC7BL0Wt+5oRIE7nwUm5Q0VGV3Wl9A/G7Y7tqw==
 
 "@itwin/itwinui-icons-react@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
- Updated to latest itwinui-css
- Added inline width to wizard step, calculated based on total steps (needed after https://github.com/iTwin/iTwinUI/pull/104)
- Removed before/after tracks from non-default wizard steps (needed after https://github.com/iTwin/iTwinUI/pull/119)
- Updated icons packages (paths fixed in https://github.com/iTwin/iTwinUI-icons/pull/13)
- Added additional progress indicator sizes (from https://github.com/iTwin/iTwinUI/issues/79)