### PR TITLE
Add ability to have themes work properly in popup window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@
 
 ### What's new
 
-- **Added number range filter to `Table`.** Use `tableFilters.NumberRangeFilter`.\*\*
-- **Update `ThemeProvider` component to allow optional owningDocument prop** to allow use in popup browser windows.
-- **Update `useTheme` hook to allow specification of owningDocument** to allow use in popup browser windows.
+- **Added number range filter to `Table`.** Use `tableFilters.NumberRangeFilter`.
+- **Updated `ThemeProvider` component and `useTheme` hook to allow specification of ownerDocument**. This provides support for theme in popup browser windows.
 
 ## [1.5.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### What's new
 
-- **Added number range filter to `Table`.** Use `tableFilters.NumberRangeFilter`.
+- **Added number range filter to `Table`.** Use `tableFilters.NumberRangeFilter`.\*\*
+- **Update `ThemeProvider` component to allow optional owningDocument prop** to allow use in popup browser windows.
+- **Update `useTheme` hook to allow specification of owningDocument** to allow use in popup browser windows.
 
 ## [1.5.0]
 

--- a/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -48,7 +48,12 @@ it('should set light theme specifying ownerDocument', () => {
     `<!DOCTYPE html><body><p>Test</p></body>`,
     'text/html',
   );
-  render(<ThemeProvider theme='light' ownerDocument={testDocument} />);
+  render(
+    <ThemeProvider
+      theme='light'
+      themeOptions={{ ownerDocument: testDocument }}
+    />,
+  );
   expectLightTheme(testDocument);
 });
 

--- a/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -44,9 +44,12 @@ it('should set light theme', () => {
 });
 
 it('should set light theme specifying ownerDocument', () => {
-  const ownerDocument = new Document();
-  render(<ThemeProvider theme='light' ownerDocument={ownerDocument} />);
-  expectLightTheme(ownerDocument);
+  const testDocument = new DOMParser().parseFromString(
+    `<!DOCTYPE html><body><p>Test</p></body>`,
+    'text/html',
+  );
+  render(<ThemeProvider theme='light' ownerDocument={testDocument} />);
+  expectLightTheme(testDocument);
 });
 
 it('should set dark theme', () => {

--- a/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -7,9 +7,11 @@ import { render } from '@testing-library/react';
 
 import { ThemeProvider } from './ThemeProvider';
 
-const expectLightTheme = () => {
-  expect(document.documentElement.classList).toContain('iui-theme-light');
-  expect(document.documentElement.classList).not.toContain('iui-theme-dark');
+const expectLightTheme = (ownerDocument = document) => {
+  expect(ownerDocument.documentElement.classList).toContain('iui-theme-light');
+  expect(ownerDocument.documentElement.classList).not.toContain(
+    'iui-theme-dark',
+  );
 };
 
 const expectDarkTheme = () => {
@@ -41,9 +43,10 @@ it('should set light theme', () => {
   expectLightTheme();
 });
 
-it('should set light theme specifying owningDocument', () => {
-  render(<ThemeProvider theme='light' owningDocument={document} />);
-  expectLightTheme();
+it('should set light theme specifying ownerDocument', () => {
+  const ownerDocument = new Document();
+  render(<ThemeProvider theme='light' ownerDocument={ownerDocument} />);
+  expectLightTheme(ownerDocument);
 });
 
 it('should set dark theme', () => {

--- a/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -41,6 +41,11 @@ it('should set light theme', () => {
   expectLightTheme();
 });
 
+it('should set light theme specifying owningDocument', () => {
+  render(<ThemeProvider theme='light' owningDocument={document} />);
+  expectLightTheme();
+});
+
 it('should set dark theme', () => {
   render(<ThemeProvider theme='dark' />);
   expectDarkTheme();

--- a/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.tsx
@@ -3,16 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import { ThemeType, useTheme } from '../utils/hooks/useTheme';
-
-export type ThemeOptions = {
-  /**
-   * Document to which the theme will be applied.
-   * Can be specified to handle popup windows.
-   * @default document
-   */
-  ownerDocument?: Document;
-};
+import { ThemeOptions, ThemeType, useTheme } from '../utils/hooks/useTheme';
 
 export type ThemeProviderProps = {
   /**

--- a/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.tsx
@@ -15,18 +15,20 @@ export type ThemeProviderProps = {
    */
   children?: React.ReactNode;
   /**
-   * Optional document specification to support popup windows.
+   * Document to which the theme will be applied.
+   * Can be specified to handle popup windows.
+   * @default document
    */
-  owningDocument?: Document;
+  ownerDocument?: Document;
 };
 
 /**
  * Component providing global styles that are required for all components and allows changing theme.
  */
 export const ThemeProvider = (props: ThemeProviderProps) => {
-  const { theme, children, owningDocument } = props;
+  const { theme, children, ownerDocument } = props;
 
-  useTheme(theme, owningDocument);
+  useTheme(theme, ownerDocument);
   return <>{children}</>;
 };
 

--- a/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.tsx
@@ -5,6 +5,15 @@
 import React from 'react';
 import { ThemeType, useTheme } from '../utils/hooks/useTheme';
 
+export type ThemeOptions = {
+  /**
+   * Document to which the theme will be applied.
+   * Can be specified to handle popup windows.
+   * @default document
+   */
+  ownerDocument?: Document;
+};
+
 export type ThemeProviderProps = {
   /**
    * Theme to be applied. If not set, light theme will be used.
@@ -15,20 +24,18 @@ export type ThemeProviderProps = {
    */
   children?: React.ReactNode;
   /**
-   * Document to which the theme will be applied.
-   * Can be specified to handle popup windows.
-   * @default document
+   * Options that can be specified to override default theming behavior.
    */
-  ownerDocument?: Document;
+  themeOptions?: ThemeOptions;
 };
 
 /**
  * Component providing global styles that are required for all components and allows changing theme.
  */
 export const ThemeProvider = (props: ThemeProviderProps) => {
-  const { theme, children, ownerDocument } = props;
+  const { theme, children, themeOptions } = props;
 
-  useTheme(theme, ownerDocument);
+  useTheme(theme, themeOptions);
   return <>{children}</>;
 };
 

--- a/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.tsx
@@ -14,15 +14,19 @@ export type ThemeProviderProps = {
    * Optional children.
    */
   children?: React.ReactNode;
+  /**
+   * Optional document specification to support popup windows.
+   */
+  owningDocument?: Document;
 };
 
 /**
  * Component providing global styles that are required for all components and allows changing theme.
  */
 export const ThemeProvider = (props: ThemeProviderProps) => {
-  const { theme, children } = props;
+  const { theme, children, owningDocument } = props;
 
-  useTheme(theme);
+  useTheme(theme, owningDocument);
   return <>{children}</>;
 };
 

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -11,40 +11,38 @@ export type ThemeType = 'light' | 'dark' | 'os';
  * Hook that applies styling and theme to all components.
  * Defaults to light theme if none provided or set elsewhere.
  * @param theme Light, dark, or based on OS setting.
+ * @param ownerDocument Document to which the theme will be applied. Defaults to `document`.
  */
-export const useTheme = (
-  theme?: ThemeType,
-  owningDocument = document,
-): void => {
+export const useTheme = (theme?: ThemeType, ownerDocument = document): void => {
   React.useLayoutEffect(() => {
-    if (!owningDocument.body.classList.contains('iui-body')) {
-      owningDocument.body.classList.add('iui-body');
+    if (!ownerDocument.body.classList.contains('iui-body')) {
+      ownerDocument.body.classList.add('iui-body');
     }
-  }, [owningDocument]);
+  }, [ownerDocument]);
 
   React.useLayoutEffect(() => {
     switch (theme) {
       case 'light':
-        addLightTheme(owningDocument);
+        addLightTheme(ownerDocument);
         break;
       case 'dark':
-        addDarkTheme(owningDocument);
+        addDarkTheme(ownerDocument);
         break;
       case 'os':
         if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
-          addDarkTheme(owningDocument);
+          addDarkTheme(ownerDocument);
         } else {
-          addLightTheme(owningDocument);
+          addLightTheme(ownerDocument);
         }
         break;
       default:
         if (
-          !owningDocument.documentElement.classList.value.includes('iui-theme')
+          !ownerDocument.documentElement.classList.value.includes('iui-theme')
         ) {
-          addLightTheme(owningDocument);
+          addLightTheme(ownerDocument);
         }
     }
-  }, [owningDocument, theme]);
+  }, [ownerDocument, theme]);
 };
 
 const addLightTheme = (ownerDocument: Document) => {

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -12,42 +12,47 @@ export type ThemeType = 'light' | 'dark' | 'os';
  * Defaults to light theme if none provided or set elsewhere.
  * @param theme Light, dark, or based on OS setting.
  */
-export const useTheme = (theme?: ThemeType): void => {
+export const useTheme = (
+  theme?: ThemeType,
+  owningDocument = document,
+): void => {
   React.useLayoutEffect(() => {
-    if (!document.body.classList.contains('iui-body')) {
-      document.body.classList.add('iui-body');
+    if (!owningDocument.body.classList.contains('iui-body')) {
+      owningDocument.body.classList.add('iui-body');
     }
-  }, []);
+  }, [owningDocument]);
 
   React.useLayoutEffect(() => {
     switch (theme) {
       case 'light':
-        addLightTheme();
+        addLightTheme(owningDocument);
         break;
       case 'dark':
-        addDarkTheme();
+        addDarkTheme(owningDocument);
         break;
       case 'os':
         if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
-          addDarkTheme();
+          addDarkTheme(owningDocument);
         } else {
-          addLightTheme();
+          addLightTheme(owningDocument);
         }
         break;
       default:
-        if (!document.documentElement.classList.value.includes('iui-theme')) {
-          addLightTheme();
+        if (
+          !owningDocument.documentElement.classList.value.includes('iui-theme')
+        ) {
+          addLightTheme(owningDocument);
         }
     }
-  }, [theme]);
+  }, [owningDocument, theme]);
 };
 
-const addLightTheme = () => {
-  document.documentElement.classList.add('iui-theme-light');
-  document.documentElement.classList.remove('iui-theme-dark');
+const addLightTheme = (ownerDocument: Document) => {
+  ownerDocument.documentElement.classList.add('iui-theme-light');
+  ownerDocument.documentElement.classList.remove('iui-theme-dark');
 };
 
-const addDarkTheme = () => {
-  document.documentElement.classList.add('iui-theme-dark');
-  document.documentElement.classList.remove('iui-theme-light');
+const addDarkTheme = (ownerDocument: Document) => {
+  ownerDocument.documentElement.classList.add('iui-theme-dark');
+  ownerDocument.documentElement.classList.remove('iui-theme-light');
 };

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -4,7 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import '@itwin/itwinui-css/css/global.css';
-import { ThemeOptions } from '../../ThemeProvider/ThemeProvider';
+
+export type ThemeOptions = {
+  /**
+   * Document to which the theme will be applied.
+   * Can be specified to handle popup windows.
+   * @default document
+   */
+  ownerDocument?: Document;
+};
 
 export type ThemeType = 'light' | 'dark' | 'os';
 

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import '@itwin/itwinui-css/css/global.css';
+import { ThemeOptions } from '../../ThemeProvider/ThemeProvider';
 
 export type ThemeType = 'light' | 'dark' | 'os';
 
@@ -11,9 +12,13 @@ export type ThemeType = 'light' | 'dark' | 'os';
  * Hook that applies styling and theme to all components.
  * Defaults to light theme if none provided or set elsewhere.
  * @param theme Light, dark, or based on OS setting.
- * @param ownerDocument Document to which the theme will be applied. Defaults to `document`.
+ * @param themeOptions Options that override default theming behavior.
  */
-export const useTheme = (theme?: ThemeType, ownerDocument = document): void => {
+export const useTheme = (
+  theme?: ThemeType,
+  themeOptions?: ThemeOptions,
+): void => {
+  const ownerDocument = themeOptions?.ownerDocument ?? document;
   React.useLayoutEffect(() => {
     if (!ownerDocument.body.classList.contains('iui-body')) {
       ownerDocument.body.classList.add('iui-body');


### PR DESCRIPTION
Add ability to have themes work properly in popup window by:

- adding `ThemeOptions` type with an optional `ownerDocument` property
- adding optional `themeOptions` argument to both `useTheme` and `ThemeProvider`

This PR addresses issue https://github.com/iTwin/iTwinUI-react/issues/96. 