### PR TITLE
Replace document calls for popup window support

### DIFF
--- a/src/core/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.test.tsx
@@ -18,10 +18,7 @@ function assertBaseElement(menu: HTMLUListElement, role = 'menu') {
   });
 }
 
-function renderComponent(
-  props?: Partial<DropdownMenuProps>,
-  renderContainer?: HTMLElement,
-) {
+function renderComponent(props?: Partial<DropdownMenuProps>) {
   return render(
     <DropdownMenu
       menuItems={(close) => [
@@ -39,7 +36,6 @@ function renderComponent(
     >
       <Button>Click here</Button>
     </DropdownMenu>,
-    renderContainer && { container: renderContainer },
   );
 }
 

--- a/src/core/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.test.tsx
@@ -146,23 +146,3 @@ it('should close menu on pressing escape key', () => {
   const tippy = document.querySelector('[data-tippy-root]') as HTMLElement;
   expect(tippy.style.visibility).toEqual('hidden');
 });
-
-it('should not respond to events in the wrong document', () => {
-  const mockDocument = new DOMParser().parseFromString(
-    `<!DOCTYPE html><html><body></body></html>`,
-    'text/html',
-  );
-
-  const { container } = renderComponent(
-    undefined,
-    mockDocument.documentElement.appendChild(mockDocument.createElement('div')),
-  );
-
-  const button = container.querySelector('.iui-button') as HTMLButtonElement;
-  button.click();
-
-  // Pressing Esc on `document` should not close menu
-  fireEvent.keyDown(document, { key: 'Escape' });
-  const tippy = mockDocument.querySelector('[data-tippy-root]') as HTMLElement;
-  expect(tippy.style.visibility).toEqual('visible');
-});

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -51,10 +51,15 @@ export type ModalProps = {
   id?: string;
   /**
    * Id of the root where the modal will be rendered in.
-   * If nothing set, RootId will be the default value of the Portal Component.
    * @default 'iui-react-portal-container'
    */
   modalRootId?: string;
+  /**
+   * Document where the modal will be rendered.
+   * Can be specified to render in a different document (e.g. a popup window).
+   * @default document
+   */
+  ownerDocument?: Document;
   /**
    * Content of the modal.
    */
@@ -96,12 +101,13 @@ export const Modal = (props: ModalProps) => {
     style,
     children,
     modalRootId = 'iui-react-portal-container',
+    ownerDocument = document,
     ...rest
   } = props;
 
   useTheme();
 
-  const container = getContainer(modalRootId);
+  const container = getContainer(modalRootId, ownerDocument);
 
   const overlayRef = React.useRef<HTMLDivElement>(null);
 
@@ -116,15 +122,15 @@ export const Modal = (props: ModalProps) => {
 
   React.useEffect(() => {
     if (isOpen) {
-      originalBodyOverflow.current = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
+      originalBodyOverflow.current = ownerDocument.body.style.overflow;
+      ownerDocument.body.style.overflow = 'hidden';
     } else {
-      document.body.style.overflow = originalBodyOverflow.current;
+      ownerDocument.body.style.overflow = originalBodyOverflow.current;
     }
     return () => {
-      document.body.style.overflow = originalBodyOverflow.current;
+      ownerDocument.body.style.overflow = originalBodyOverflow.current;
     };
-  }, [isOpen]);
+  }, [isOpen, ownerDocument]);
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     // Prevents React from resetting its properties

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -606,7 +606,7 @@ it('should not trigger sorting when filter is clicked', () => {
   expect(onSort).not.toHaveBeenCalled();
 });
 
-it('should render filter toggle in the correct document', () => {
+it('should render filter dropdown in the correct document', () => {
   const mockDocument = new DOMParser().parseFromString(
     `<!DOCTYPE html><html><body><div></div></body></html>`,
     'text/html',
@@ -638,8 +638,6 @@ it('should render filter toggle in the correct document', () => {
   const filterIcon = container.querySelector('.iui-filter') as HTMLElement;
   expect(filterIcon).toBeTruthy();
   filterIcon.click();
-
-  console.log(container.ownerDocument.body.innerHTML);
 
   expect(mockDocument.querySelector('.iui-column-filter')).toBeTruthy();
   expect(document.querySelector('.iui-column-filter')).toBeFalsy();

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -55,6 +55,7 @@ const mockedData = (count = 3) =>
 function renderComponent(
   initialsProps?: Partial<TableProps>,
   onViewClick?: () => void,
+  renderContainer?: HTMLElement,
 ) {
   const defaultProps: TableProps = {
     columns: columns(onViewClick),
@@ -64,7 +65,10 @@ function renderComponent(
   };
 
   const props = { ...defaultProps, ...initialsProps };
-  return render(<Table {...props} />);
+  return render(
+    <Table {...props} />,
+    renderContainer && { container: renderContainer },
+  );
 }
 
 function assertRowsData(
@@ -600,4 +604,43 @@ it('should not trigger sorting when filter is clicked', () => {
 
   expect(onFilter).toHaveBeenCalled();
   expect(onSort).not.toHaveBeenCalled();
+});
+
+it('should render filter toggle in the correct document', () => {
+  const mockDocument = new DOMParser().parseFromString(
+    `<!DOCTYPE html><html><body><div></div></body></html>`,
+    'text/html',
+  );
+  const mockContainer = mockDocument.querySelector('div') as HTMLDivElement;
+
+  const onFilter = jest.fn();
+  const mockedColumns = [
+    {
+      Header: 'Header name',
+      columns: [
+        {
+          id: 'name',
+          Header: 'Name',
+          accessor: 'name',
+          Filter: tableFilters.TextFilter(),
+          fieldType: 'text',
+        },
+      ],
+    },
+  ];
+  const { container } = renderComponent(
+    { columns: mockedColumns, onFilter },
+    undefined,
+    mockContainer,
+  );
+  expect(container.querySelector('.iui-tables-table')).toBeTruthy();
+
+  const filterIcon = container.querySelector('.iui-filter') as HTMLElement;
+  expect(filterIcon).toBeTruthy();
+  filterIcon.click();
+
+  console.log(container.ownerDocument.body.innerHTML);
+
+  expect(mockDocument.querySelector('.iui-column-filter')).toBeTruthy();
+  expect(document.querySelector('.iui-column-filter')).toBeFalsy();
 });

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -170,6 +170,8 @@ export const Table = <
 
   useTheme();
 
+  const tableRef = React.useRef<HTMLDivElement>(null);
+
   const defaultColumn = React.useMemo(
     () => ({
       maxWidth: 0,
@@ -318,6 +320,7 @@ export const Table = <
 
   return (
     <div
+      ref={tableRef}
       {...getTableProps({
         className: cx('iui-tables-table', className),
         style,
@@ -349,7 +352,10 @@ export const Table = <
                   <div {...columnProps} key={columnProps.key}>
                     {column.render('Header')}
                     {!isLoading && data.length != 0 && (
-                      <FilterToggle column={column} />
+                      <FilterToggle
+                        column={column}
+                        ownerDocument={tableRef.current?.ownerDocument}
+                      />
                     )}
                     {!isLoading && data.length != 0 && column.canSort && (
                       <div className='iui-sort'>

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -170,7 +170,7 @@ export const Table = <
 
   useTheme();
 
-  const tableRef = React.useRef<HTMLDivElement>(null);
+  const [ownerDocument, setOwnerDocument] = React.useState<Document>();
 
   const defaultColumn = React.useMemo(
     () => ({
@@ -320,7 +320,7 @@ export const Table = <
 
   return (
     <div
-      ref={tableRef}
+      ref={(element) => setOwnerDocument(element?.ownerDocument)}
       {...getTableProps({
         className: cx('iui-tables-table', className),
         style,
@@ -354,7 +354,7 @@ export const Table = <
                     {!isLoading && data.length != 0 && (
                       <FilterToggle
                         column={column}
-                        ownerDocument={tableRef.current?.ownerDocument}
+                        ownerDocument={ownerDocument}
                       />
                     )}
                     {!isLoading && data.length != 0 && column.canSort && (

--- a/src/core/Table/filters/FilterToggle.tsx
+++ b/src/core/Table/filters/FilterToggle.tsx
@@ -13,6 +13,7 @@ import { Popover } from '../../utils/Popover';
 
 export type FilterToggleProps<T extends Record<string, unknown>> = {
   column: HeaderGroup<T>;
+  ownerDocument?: Document;
 };
 
 /**
@@ -21,7 +22,7 @@ export type FilterToggleProps<T extends Record<string, unknown>> = {
 export const FilterToggle = <T extends Record<string, unknown>>(
   props: FilterToggleProps<T>,
 ) => {
-  const { column } = props;
+  const { column, ownerDocument = document } = props;
 
   useTheme();
 
@@ -49,7 +50,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
           placement='bottom'
           visible={isVisible}
           onClickOutside={close}
-          appendTo={document.body}
+          appendTo={ownerDocument.body}
         >
           <div
             className={cx('iui-filter', {

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -85,6 +85,9 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
 
 export const hideOnEsc = {
   fn(instance: Instance) {
+    // will always refer to the correct document instance (e.g. in a popout window)
+    const _document = instance.reference?.ownerDocument ?? document;
+
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         instance.hide();
@@ -93,10 +96,10 @@ export const hideOnEsc = {
 
     return {
       onShow() {
-        document.addEventListener('keydown', onKeyDown);
+        _document.addEventListener('keydown', onKeyDown);
       },
       onHide() {
-        document.removeEventListener('keydown', onKeyDown);
+        _document.removeEventListener('keydown', onKeyDown);
       },
     };
   },

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -85,9 +85,6 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
 
 export const hideOnEsc = {
   fn(instance: Instance) {
-    // will always refer to the correct document instance (e.g. in a popout window)
-    const _document = instance.reference?.ownerDocument ?? document;
-
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         instance.hide();
@@ -96,10 +93,10 @@ export const hideOnEsc = {
 
     return {
       onShow() {
-        _document.addEventListener('keydown', onKeyDown);
+        instance.popper.addEventListener('keydown', onKeyDown);
       },
       onHide() {
-        _document.removeEventListener('keydown', onKeyDown);
+        instance.popper.removeEventListener('keydown', onKeyDown);
       },
     };
   },

--- a/src/core/utils/common.spec.tsx
+++ b/src/core/utils/common.spec.tsx
@@ -15,7 +15,7 @@ it('should return color for given user email', () => {
 it('should create container', () => {
   const container = getContainer('test-id');
   expect(document.getElementById('test-id')).toBeTruthy();
-  expect(getContainer('test-id')).toEqual(container);
+  expect(getContainer('test-id')).toBe(container);
 });
 
 it('should respect ownerDocument arg', () => {
@@ -26,5 +26,6 @@ it('should respect ownerDocument arg', () => {
 
   const container = getContainer('test-id', mockDocument);
   expect(mockDocument.getElementById('test-id')).toBeTruthy();
-  expect(getContainer('test-id')).toEqual(container);
+  expect(getContainer('test-id', mockDocument)).toBe(container);
+  expect(getContainer('test-id', document)).not.toBe(container);
 });

--- a/src/core/utils/common.spec.tsx
+++ b/src/core/utils/common.spec.tsx
@@ -17,3 +17,14 @@ it('should create container', () => {
   expect(document.getElementById('test-id')).toBeTruthy();
   expect(getContainer('test-id')).toEqual(container);
 });
+
+it('should respect ownerDocument arg', () => {
+  const mockDocument = new DOMParser().parseFromString(
+    `<!DOCTYPE html><html><body></body></html>`,
+    'text/html',
+  );
+
+  const container = getContainer('test-id', mockDocument);
+  expect(mockDocument.getElementById('test-id')).toBeTruthy();
+  expect(getContainer('test-id')).toEqual(container);
+});

--- a/src/core/utils/common.tsx
+++ b/src/core/utils/common.tsx
@@ -49,14 +49,14 @@ export const getUserColor = (emailOrName: string) => {
  * Mostly used for dynamic components like Modal or Toast.
  *
  * @param containerId id of the container to find or create
- * @param hostDocument Defaults to document but can be changed to support popup windows.
+ * @param ownerDocument Can be changed if the container should be in a different document (e.g. in popup).
  */
-export const getContainer = (containerId: string, hostDocument = document) => {
-  let container = hostDocument.getElementById(containerId);
+export const getContainer = (containerId: string, ownerDocument = document) => {
+  let container = ownerDocument.getElementById(containerId);
   if (container == null) {
-    container = hostDocument.createElement('div');
+    container = ownerDocument.createElement('div');
     container.setAttribute('id', containerId);
-    hostDocument.body.appendChild(container);
+    ownerDocument.body.appendChild(container);
   }
   return container;
 };

--- a/src/core/utils/common.tsx
+++ b/src/core/utils/common.tsx
@@ -47,13 +47,16 @@ export const getUserColor = (emailOrName: string) => {
 /**
  * Get the container as a child of body, or create one if it doesn't exist.
  * Mostly used for dynamic components like Modal or Toast.
+ *
+ * @param containerId id of the container to find or create
+ * @param hostDocument Defaults to document but can be changed to support popup windows.
  */
-export const getContainer = (containerId: string) => {
-  let container = document.getElementById(containerId);
+export const getContainer = (containerId: string, hostDocument = document) => {
+  let container = hostDocument.getElementById(containerId);
   if (container == null) {
-    container = document.createElement('div');
+    container = hostDocument.createElement('div');
     container.setAttribute('id', containerId);
-    document.body.appendChild(container);
+    hostDocument.body.appendChild(container);
   }
   return container;
 };

--- a/stories/core/Modal.stories.tsx
+++ b/stories/core/Modal.stories.tsx
@@ -21,6 +21,7 @@ export default {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
     onClose: { control: { disable: true } },
+    ownerDocument: { control: { disable: true } },
   },
 } as Meta<ModalProps>;
 


### PR DESCRIPTION
- [x] `getContainer`: Added `ownerDocument` arg and test
- [x] `Modal`: Added `ownerDocument` prop (passed to getContainer)
- [x] `Popover`: Updated `hideOnEsc` plugin to use popper element instead of `document`
- [x] `Table`: added `ownerDocument` (from table ref) to `FilterToggle`
- [ ] `useTheme`: Hook fixed in #97 but none of the components use that arg currently

<details>
<summary>All references to "document" in project</summary>

![image](https://user-images.githubusercontent.com/9084735/120391670-614eca00-c2fd-11eb-94b7-8085db241e1a.png)
</details>
