### PR TITLE
Fix storybook not loading in IE

### DIFF
--- a/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -69,6 +69,7 @@ it('should set default theme', () => {
   render(<ThemeProvider theme='dark' />);
   expectDarkTheme();
 
+  // should preserve dark theme since it was set before
   render(<ThemeProvider />);
   expectDarkTheme();
 });

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -50,7 +50,7 @@ export const useTheme = (
         break;
       default:
         if (
-          !ownerDocument.documentElement.classList.value.includes('iui-theme')
+          ownerDocument.documentElement.className.indexOf('iui-theme') === -1
         ) {
           addLightTheme(ownerDocument);
         }


### PR DESCRIPTION
Changed `classList.value` usage to `className` in useTheme. Fixes #100 

Also added comment to clarify what the "default theme" test does.