### PR TITLE
Close dropdown menu when tabbing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Fixed `DropdownMenu` not closing when tabbing out.**
+  - Also fixed derived components: `DropdownButton`, `SplitButton`, and `Select`.
+
 ## [1.7.0]
 
 `2021-06-07`

--- a/src/core/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.test.tsx
@@ -129,7 +129,7 @@ it('should focus target after hide', () => {
   expect(document.activeElement).toEqual(button);
 });
 
-it('should close menu on pressing escape key', () => {
+it('should close menu on pressing escape or tab key', () => {
   const { container } = renderComponent();
 
   const button = container.querySelector('.iui-button') as HTMLButtonElement;
@@ -138,7 +138,15 @@ it('should close menu on pressing escape key', () => {
   const menu = document.querySelector('.iui-menu') as HTMLUListElement;
   assertBaseElement(menu);
 
-  fireEvent.keyDown(menu, { key: 'Escape' });
   const tippy = document.querySelector('[data-tippy-root]') as HTMLElement;
+  expect(tippy.style.visibility).toEqual('visible');
+
+  fireEvent.keyDown(menu, { key: 'Escape' });
+  expect(tippy.style.visibility).toEqual('hidden');
+
+  button.click();
+  expect(tippy.style.visibility).toEqual('visible');
+
+  fireEvent.keyDown(menu, { key: 'Tab' });
   expect(tippy.style.visibility).toEqual('hidden');
 });

--- a/src/core/DropdownMenu/DropdownMenu.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.tsx
@@ -68,6 +68,8 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
   const open = React.useCallback(() => setIsVisible(true), []);
   const close = React.useCallback(() => setIsVisible(false), []);
 
+  const [closedByBlur, setClosedByBlur] = React.useState(false);
+
   const targetRef = React.useRef<HTMLElement>(null);
 
   const onShowHandler = React.useCallback(
@@ -92,12 +94,18 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
   return (
     <Popover
       content={
-        <Menu className={className} style={style} role={role}>
-          {React.useMemo(() => menuItems(close), [menuItems, close])}
-        </Menu>
+        <div
+          onBlur={(event) => {
+            close();
+            setClosedByBlur(event.relatedTarget === targetRef.current);
+          }}
+        >
+          <Menu className={className} style={style} role={role}>
+            {React.useMemo(() => menuItems(close), [menuItems, close])}
+          </Menu>
+        </div>
       }
       visible={trigger === undefined ? isVisible : undefined}
-      onClickOutside={close}
       placement={placement}
       onShow={onShowHandler}
       onHide={onHideHandler}
@@ -108,7 +116,10 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ref: mergeRefs(targetRef, (props.children as any).ref),
         onClick: (args: unknown) => {
-          trigger === undefined && (isVisible ? close() : open());
+          if (trigger === undefined && !closedByBlur) {
+            isVisible ? close() : open();
+          }
+          setClosedByBlur(false);
           (children as JSX.Element).props.onClick?.(args);
         },
       })}

--- a/src/core/DropdownMenu/DropdownMenu.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.tsx
@@ -97,6 +97,7 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
         </Menu>
       }
       visible={trigger === undefined ? isVisible : undefined}
+      onClickOutside={close}
       placement={placement}
       onShow={onShowHandler}
       onHide={onHideHandler}

--- a/src/core/DropdownMenu/DropdownMenu.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.tsx
@@ -68,8 +68,6 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
   const open = React.useCallback(() => setIsVisible(true), []);
   const close = React.useCallback(() => setIsVisible(false), []);
 
-  const [closedByBlur, setClosedByBlur] = React.useState(false);
-
   const targetRef = React.useRef<HTMLElement>(null);
 
   const onShowHandler = React.useCallback(
@@ -94,16 +92,9 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
   return (
     <Popover
       content={
-        <div
-          onBlur={(event) => {
-            close();
-            setClosedByBlur(event.relatedTarget === targetRef.current);
-          }}
-        >
-          <Menu className={className} style={style} role={role}>
-            {React.useMemo(() => menuItems(close), [menuItems, close])}
-          </Menu>
-        </div>
+        <Menu className={className} style={style} role={role}>
+          {React.useMemo(() => menuItems(close), [menuItems, close])}
+        </Menu>
       }
       visible={trigger === undefined ? isVisible : undefined}
       placement={placement}
@@ -116,10 +107,7 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ref: mergeRefs(targetRef, (props.children as any).ref),
         onClick: (args: unknown) => {
-          if (trigger === undefined && !closedByBlur) {
-            isVisible ? close() : open();
-          }
-          setClosedByBlur(false);
+          trigger === undefined && (isVisible ? close() : open());
           (children as JSX.Element).props.onClick?.(args);
         },
       })}

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -112,18 +112,14 @@ export const hideOnBlur = {
   fn(instance: Instance) {
     return {
       onCreate() {
-        instance.popper.addEventListener(
-          'focusout',
-          (event) => {
-            if (
-              event.relatedTarget && // only hide when focus is on a valid target
-              !instance.popper.contains(event.relatedTarget as Node)
-            ) {
-              instance.hide();
-            }
-          },
-          { capture: true },
-        );
+        instance.popper.addEventListener('focusout', (event) => {
+          if (
+            event.relatedTarget && // only hide when focus is on a valid target
+            !instance.popper.contains(event.relatedTarget as Node)
+          ) {
+            setTimeout(() => instance.hide(), 100);
+          }
+        });
       },
     };
   },

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -70,7 +70,12 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     role: undefined,
     offset: [0, 0],
     ...props,
-    plugins: [lazyLoad, removeTabIndex, hideOnEsc, ...(props.plugins || [])],
+    plugins: [
+      lazyLoad,
+      removeTabIndex,
+      hideOnEscOrTab,
+      ...(props.plugins || []),
+    ],
   };
 
   if (props.render) {
@@ -83,11 +88,26 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
   return <Tippy {...computedProps} ref={refs} />;
 });
 
-export const hideOnEsc = {
+/**
+ * Plugin to hide tippy when either Esc key is pressed,
+ * or when the content inside is not tabbable and Tab key is pressed.
+ */
+export const hideOnEscOrTab = {
   fn(instance: Instance) {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        instance.hide();
+      switch (event.key) {
+        case 'Escape':
+          instance.hide();
+          break;
+        case 'Tab':
+          const descendents = Array.from<HTMLElement>(
+            instance.popper.querySelectorAll('*'),
+          );
+          if (!descendents.some((el) => el?.tabIndex >= 0)) {
+            event.preventDefault();
+            instance.hide();
+          }
+          break;
       }
     };
 

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -89,7 +89,7 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
 });
 
 /**
- * Plugin to hide tippy when either Esc key is pressed,
+ * Plugin to hide Popover when either Esc key is pressed,
  * or when the content inside is not tabbable and Tab key is pressed.
  */
 export const hideOnEscOrTab = {
@@ -109,6 +109,7 @@ export const hideOnEscOrTab = {
           break;
         case 'Tab':
           if (shouldHideOnTab()) {
+            event.shiftKey && event.preventDefault(); // focus popover target on Shift+Tab
             instance.hide();
           }
           break;

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -70,7 +70,13 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     role: undefined,
     offset: [0, 0],
     ...props,
-    plugins: [lazyLoad, removeTabIndex, hideOnEsc, ...(props.plugins || [])],
+    plugins: [
+      lazyLoad,
+      removeTabIndex,
+      hideOnEsc,
+      hideOnBlur,
+      ...(props.plugins || []),
+    ],
   };
 
   if (props.render) {
@@ -97,6 +103,27 @@ export const hideOnEsc = {
       },
       onHide() {
         document.removeEventListener('keydown', onKeyDown);
+      },
+    };
+  },
+};
+
+export const hideOnBlur = {
+  fn(instance: Instance) {
+    return {
+      onCreate() {
+        instance.popper.addEventListener(
+          'focusout',
+          (event) => {
+            if (
+              event.relatedTarget && // only hide when focus is on a valid target
+              !instance.popper.contains(event.relatedTarget as Node)
+            ) {
+              instance.hide();
+            }
+          },
+          { capture: true },
+        );
       },
     };
   },

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -94,17 +94,21 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
  */
 export const hideOnEscOrTab = {
   fn(instance: Instance) {
+    /** @returns true if none of the children are tabbable */
+    const shouldHideOnTab = () => {
+      const descendents = Array.from<HTMLElement>(
+        instance.popper.querySelectorAll('*'),
+      );
+      return !descendents.some((el) => el?.tabIndex >= 0);
+    };
+
     const onKeyDown = (event: KeyboardEvent) => {
       switch (event.key) {
         case 'Escape':
           instance.hide();
           break;
         case 'Tab':
-          const descendents = Array.from<HTMLElement>(
-            instance.popper.querySelectorAll('*'),
-          );
-          if (!descendents.some((el) => el?.tabIndex >= 0)) {
-            event.preventDefault();
+          if (shouldHideOnTab()) {
             instance.hide();
           }
           break;

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -70,13 +70,7 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     role: undefined,
     offset: [0, 0],
     ...props,
-    plugins: [
-      lazyLoad,
-      removeTabIndex,
-      hideOnEsc,
-      hideOnBlur,
-      ...(props.plugins || []),
-    ],
+    plugins: [lazyLoad, removeTabIndex, hideOnEsc, ...(props.plugins || [])],
   };
 
   if (props.render) {
@@ -103,23 +97,6 @@ export const hideOnEsc = {
       },
       onHide() {
         document.removeEventListener('keydown', onKeyDown);
-      },
-    };
-  },
-};
-
-export const hideOnBlur = {
-  fn(instance: Instance) {
-    return {
-      onCreate() {
-        instance.popper.addEventListener('focusout', (event) => {
-          if (
-            event.relatedTarget && // only hide when focus is on a valid target
-            !instance.popper.contains(event.relatedTarget as Node)
-          ) {
-            setTimeout(() => instance.hide(), 100);
-          }
-        });
       },
     };
   },

--- a/stories/core/DropdownMenu.stories.tsx
+++ b/stories/core/DropdownMenu.stories.tsx
@@ -9,7 +9,7 @@ import { DropdownMenu, IconButton, MenuItem } from '../../src/core';
 import { action } from '@storybook/addon-actions';
 import SvgClipboard from '@itwin/itwinui-icons-react/cjs/icons/Clipboard';
 import SvgCrop from '@itwin/itwinui-icons-react/cjs/icons/Crop';
-import SvgMoreSmall from '@itwin/itwinui-icons-react/cjs/icons/MoreSmall';
+import SvgMore from '@itwin/itwinui-icons-react/cjs/icons/More';
 import SvgMove from '@itwin/itwinui-icons-react/cjs/icons/Move';
 
 export default {
@@ -44,7 +44,7 @@ export const Basic: Story<DropdownMenuProps> = (args) => {
     <div style={{ minHeight: 150 }}>
       <DropdownMenu menuItems={menuItems || dropdownMenuItems} {...rest}>
         <IconButton>
-          <SvgMoreSmall />
+          <SvgMore />
         </IconButton>
       </DropdownMenu>
     </div>
@@ -72,7 +72,7 @@ export const WithIcons: Story<DropdownMenuProps> = (args) => {
     <div style={{ minHeight: 150 }}>
       <DropdownMenu menuItems={menuItems || dropdownMenuItems} {...rest}>
         <IconButton>
-          <SvgMoreSmall />
+          <SvgMore />
         </IconButton>
       </DropdownMenu>
     </div>
@@ -104,7 +104,7 @@ export const WithBadges: Story<DropdownMenuProps> = (args) => {
     <div style={{ minHeight: 150 }}>
       <DropdownMenu menuItems={menuItems || dropdownMenuItems} {...rest}>
         <IconButton>
-          <SvgMoreSmall />
+          <SvgMore />
         </IconButton>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
<details>
<summary>❌ Approach 1: Add `focusout` event listener in Popover.</summary>

Doesn't work because focusout is called before click, so it closes the menu and immediately reopens it.
  - [x] Tried `stopPropagation` and `stopImmediatePropagation` on both click event and focusout
  - [x] Tried `capture: true` and `capture: false`
  - [x] Tried `setTimeout` (without delay) in focusout. Only works with arbitrary delay (e.g. 100) but it's hacky.
</details>

<details>
<summary>❌ Approach 2: Use `onBlur` on Menu and maintain state for click vs blur.</summary>

Not reliable, and is dependent on content and adds extra state management (which needs to be overridden by `visible` prop too). Got complicated real fast and was still not working perfectly between keyboard and mouse clicks when repeatedly opening/closing.
</details>

✔ **Approach 3**: Listen for "Tab" `keydown` event and hide tippy if none of the children are tabbable.

## Checklist

- [x] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] Add an entry to the changelog for any new components and changes
- [x] ~~Add screenshots of the key elements of the component below~~
- [x] Add any additional comments below describing the features you've implemented
