### PR TITLE
Combine classnames in Footer

### DIFF
--- a/src/core/Footer/Footer.test.tsx
+++ b/src/core/Footer/Footer.test.tsx
@@ -5,10 +5,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { Footer, FooterElement } from './Footer';
+import { Footer, FooterProps, FooterElement } from './Footer';
 
-const renderComponent = (elements?: FooterElement[]) => {
-  return render(<Footer customElements={elements} />);
+const renderComponent = (props?: Partial<FooterProps>) => {
+  return render(<Footer {...props} />);
 };
 
 const urls: FooterElement[] = [
@@ -63,7 +63,7 @@ it('should show all default footer elements', () => {
       title: 'Products link',
     },
   ];
-  const { container } = renderComponent(customUrls);
+  const { container } = renderComponent({ customElements: customUrls });
   const copyright = container.querySelector<HTMLLIElement>('li:first-child');
   const today = new Date();
   expect(copyright?.textContent).toBe(
@@ -76,4 +76,19 @@ it('should show all default footer elements', () => {
       expect(link.href).toBe(element.url);
     }
   });
+});
+
+it('should propagate classname and style props correctly', () => {
+  const { container } = renderComponent({
+    className: 'custom-class',
+    style: { position: 'fixed', bottom: 0 },
+  });
+
+  const footer = container.querySelector(
+    '.iui-legal-footer.custom-class',
+  ) as HTMLElement;
+
+  expect(footer).toBeTruthy();
+  expect(footer.style.position).toEqual('fixed');
+  expect(footer.style.bottom).toEqual('0px');
 });

--- a/src/core/Footer/Footer.tsx
+++ b/src/core/Footer/Footer.tsx
@@ -3,9 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
+import cx from 'classnames';
 import { useTheme } from '../utils/hooks/useTheme';
 import '@itwin/itwinui-css/css/footer.css';
-import { CommonProps } from '../utils/props';
+import { StylingProps } from '../utils/props';
 
 export type TitleTranslations = {
   termsOfService: string;
@@ -24,7 +25,7 @@ export type FooterProps = {
    * Provide localized strings.
    */
   translatedTitles?: TitleTranslations;
-} & Omit<CommonProps, 'title'>;
+} & StylingProps;
 
 export type FooterElement = {
   /**
@@ -53,7 +54,7 @@ const footerTranslations: TitleTranslations = {
  * <Footer customElements={[{title: 'Bentley', url: 'https://www.bentley.com/'}]} />
  */
 export const Footer = (props: FooterProps) => {
-  const { customElements, translatedTitles, ...rest } = props;
+  const { customElements, translatedTitles, className, ...rest } = props;
 
   useTheme();
 
@@ -79,7 +80,7 @@ export const Footer = (props: FooterProps) => {
     : defaultElements;
 
   return (
-    <footer className='iui-legal-footer' {...rest}>
+    <footer className={cx('iui-legal-footer', className)} {...rest}>
       <ul>
         <li>© {today.getFullYear()} Bentley Systems, Incorporated</li>
         {elements.map((element, index) => {

--- a/stories/core/Footer.stories.tsx
+++ b/stories/core/Footer.stories.tsx
@@ -9,6 +9,10 @@ import { Footer, FooterProps } from '../../src/core';
 export default {
   title: 'Core/Footer',
   component: Footer,
+  argTypes: {
+    className: { control: { disable: true } },
+    style: { control: { disable: true } },
+  },
 } as Meta<FooterProps>;
 
 export const Basic: Story<FooterProps> = ({


### PR DESCRIPTION
Noticed `classnames` was completely missing when I was investigating #111. So if a user were to pass a custom class, it would completely replace the `iui-legal-footer` class.

Added a test as well.