### PR TITLE
Moved ownerDocument get to function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.7.0]
+
+`2021-06-07`
+
+### What's new
+
+- **Added `TimePicker` component.**
+
+### Fixes
+
+- **Fixed `ownerDocument` in `useTheme` breaking SSR build.**
+
 ## [1.6.1]
 
 `2021-06-03`

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -26,14 +26,19 @@ export const useTheme = (
   theme?: ThemeType,
   themeOptions?: ThemeOptions,
 ): void => {
-  const ownerDocument = themeOptions?.ownerDocument ?? document;
+  const getOwnerDocument = React.useCallback(() => {
+    return themeOptions?.ownerDocument ?? document;
+  }, [themeOptions?.ownerDocument]);
+
   React.useLayoutEffect(() => {
+    const ownerDocument = getOwnerDocument();
     if (!ownerDocument.body.classList.contains('iui-body')) {
       ownerDocument.body.classList.add('iui-body');
     }
-  }, [ownerDocument]);
+  }, [getOwnerDocument]);
 
   React.useLayoutEffect(() => {
+    const ownerDocument = getOwnerDocument();
     switch (theme) {
       case 'light':
         addLightTheme(ownerDocument);
@@ -55,7 +60,7 @@ export const useTheme = (
           addLightTheme(ownerDocument);
         }
     }
-  }, [ownerDocument, theme]);
+  }, [getOwnerDocument, theme]);
 };
 
 const addLightTheme = (ownerDocument: Document) => {


### PR DESCRIPTION
After #97 SSR got broken as this line was causing issues (reported by @irenajur):
![image](https://user-images.githubusercontent.com/81580355/121000465-ed943d80-c792-11eb-9df1-c9e5294ddd8d.png)

And giving this error on build in server side:
![image](https://user-images.githubusercontent.com/81580355/121000538-013fa400-c793-11eb-8a8a-56a18b2b5de1.png)

Document is not defined in server, so I guess it has some auto checks on code (not in hooks or functions, like variables) for document and it just fails...

Solution: moved our ownerDocument assignment to function so server would not complain, but the outcome should be same.
