### PR TITLE
Fix when table columns change does not cause table rerender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - **Fixed `ownerDocument` in `useTheme` breaking SSR build.**
+- **Fixed when `Table` columns change doesn't cause rows to re-render.**
 
 ## [1.6.1]
 

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -642,3 +642,46 @@ it('should render filter dropdown in the correct document', () => {
   expect(mockDocument.querySelector('.iui-column-filter')).toBeTruthy();
   expect(document.querySelector('.iui-column-filter')).toBeFalsy();
 });
+
+it('should rerender table when columns change', () => {
+  const data = mockedData();
+  const { rerender } = render(
+    <Table
+      columns={[
+        {
+          Header: 'Header name',
+          columns: [
+            {
+              id: 'name',
+              Header: 'Name',
+              Cell: () => 'test1',
+            },
+          ],
+        },
+      ]}
+      data={data}
+      emptyTableContent='No data.'
+    />,
+  );
+  expect(screen.getAllByText('test1').length).toBe(3);
+
+  rerender(
+    <Table
+      columns={[
+        {
+          Header: 'Header name',
+          columns: [
+            {
+              id: 'name',
+              Header: 'Name',
+              Cell: () => 'test2',
+            },
+          ],
+        },
+      ]}
+      data={data}
+      emptyTableContent='No data.'
+    />,
+  );
+  expect(screen.getAllByText('test2').length).toBe(3);
+});

--- a/src/core/Table/TableRowMemoized.tsx
+++ b/src/core/Table/TableRowMemoized.tsx
@@ -66,5 +66,8 @@ export const TableRowMemoized = React.memo(
     prevProp.onBottomReached === nextProp.onBottomReached &&
     prevProp.row.original === nextProp.row.original &&
     prevProp.state.selectedRowIds?.[prevProp.row.id] ===
-      nextProp.state.selectedRowIds?.[nextProp.row.id],
+      nextProp.state.selectedRowIds?.[nextProp.row.id] &&
+    prevProp.row.cells.every(
+      (cell, index) => nextProp.row.cells[index].column === cell.column,
+    ),
 ) as typeof TableRow;


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

I added comparison of previous `columns` and new ones to `TableRowMemoized`. `columns` are the same array that user provides.
I tested with lazy-loading and it does not cause a rerender there.

Closes issue #104

## Checklist

- [x] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Add an entry to the changelog for any new components and changes
- [ ] Add screenshots of the key elements of the component
- [x] Add any additional comments describing the features you've implemented
