### PR TITLE
Replace document and window with function getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.7.1]
+
+`2021-06-08`
+
+### Fixes
+
+- **Replaced all `document` and `window` with get functions to support SSR.**
+
 ## [1.7.0]
 
 `2021-06-07`

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -168,3 +168,25 @@ import SvgClose from '@itwin/itwinui-icons-react/esm/icons/Close';
 // Bad (combining imports)
 import { SvgClose, SvgInfo } from '@itwin/itwinui-icons-react/cjs/icons';
 ```
+
+### Use `getDocument`, `getWindow` instead of direct access
+
+```jsx
+// Good
+getWindow()?.clearTimeout(1);
+```
+
+```jsx
+// Good
+getDocument()?.createElement('div');
+```
+
+```jsx
+// Bad
+window.clearTimeout(1);
+```
+
+```jsx
+// Bad
+document.createElement('div');
+```

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -155,8 +155,7 @@ export const Modal = (props: ModalProps) => {
     }
   };
 
-  return (
-    !!container &&
+  return !!container ? (
     ReactDOM.createPortal(
       isOpen && (
         <div
@@ -194,6 +193,8 @@ export const Modal = (props: ModalProps) => {
       ),
       container,
     )
+  ) : (
+    <></>
   );
 };
 

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -155,42 +155,45 @@ export const Modal = (props: ModalProps) => {
     }
   };
 
-  return ReactDOM.createPortal(
-    isOpen && (
-      <div
-        className={cx('iui-modal', 'iui-modal-visible', className)}
-        tabIndex={-1}
-        onKeyDown={handleKeyDown}
-        ref={overlayRef}
-        onMouseDown={handleMouseDown}
-        {...rest}
-      >
+  return (
+    !!container &&
+    ReactDOM.createPortal(
+      isOpen && (
         <div
-          className='iui-modal-dialog'
-          id={id}
-          style={style}
-          role='dialog'
-          aria-modal='true'
-          onMouseDown={(event) => event.stopPropagation()}
+          className={cx('iui-modal', 'iui-modal-visible', className)}
+          tabIndex={-1}
+          onKeyDown={handleKeyDown}
+          ref={overlayRef}
+          onMouseDown={handleMouseDown}
+          {...rest}
         >
-          <div className='iui-title-bar'>
-            <div className='iui-title'>{title}</div>
-            {isDismissible && (
-              <IconButton
-                size='small'
-                styleType='borderless'
-                onClick={onClose}
-                aria-label='Close'
-              >
-                <SvgClose />
-              </IconButton>
-            )}
+          <div
+            className='iui-modal-dialog'
+            id={id}
+            style={style}
+            role='dialog'
+            aria-modal='true'
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className='iui-title-bar'>
+              <div className='iui-title'>{title}</div>
+              {isDismissible && (
+                <IconButton
+                  size='small'
+                  styleType='borderless'
+                  onClick={onClose}
+                  aria-label='Close'
+                >
+                  <SvgClose />
+                </IconButton>
+              )}
+            </div>
+            {children}
           </div>
-          {children}
         </div>
-      </div>
-    ),
-    container,
+      ),
+      container,
+    )
   );
 };
 

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -10,7 +10,7 @@ import { CommonProps } from '../utils/props';
 import { useTheme } from '../utils/hooks/useTheme';
 import '@itwin/itwinui-css/css/modal.css';
 import { IconButton } from '../Buttons/IconButton';
-import { getContainer } from '../utils/common';
+import { getContainer, getDocument } from '../utils/common';
 
 export type ModalProps = {
   /**
@@ -101,7 +101,7 @@ export const Modal = (props: ModalProps) => {
     style,
     children,
     modalRootId = 'iui-react-portal-container',
-    ownerDocument = document,
+    ownerDocument = getDocument(),
     ...rest
   } = props;
 
@@ -121,6 +121,10 @@ export const Modal = (props: ModalProps) => {
   }, [isOpen]);
 
   React.useEffect(() => {
+    if (!ownerDocument) {
+      return;
+    }
+
     if (isOpen) {
       originalBodyOverflow.current = ownerDocument.body.style.overflow;
       ownerDocument.body.style.overflow = 'hidden';

--- a/src/core/Table/filters/FilterToggle.tsx
+++ b/src/core/Table/filters/FilterToggle.tsx
@@ -10,6 +10,7 @@ import { HeaderGroup } from 'react-table';
 import '@itwin/itwinui-css/css/table.css';
 import { useTheme } from '../../utils/hooks/useTheme';
 import { Popover } from '../../utils/Popover';
+import { getDocument } from '../../utils/common';
 
 export type FilterToggleProps<T extends Record<string, unknown>> = {
   column: HeaderGroup<T>;
@@ -22,7 +23,7 @@ export type FilterToggleProps<T extends Record<string, unknown>> = {
 export const FilterToggle = <T extends Record<string, unknown>>(
   props: FilterToggleProps<T>,
 ) => {
-  const { column, ownerDocument = document } = props;
+  const { column, ownerDocument = getDocument() } = props;
 
   useTheme();
 
@@ -50,7 +51,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
           placement='bottom'
           visible={isVisible}
           onClickOutside={close}
-          appendTo={ownerDocument.body}
+          appendTo={ownerDocument?.body}
         >
           <div
             className={cx('iui-filter', {

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -12,6 +12,7 @@ import cx from 'classnames';
 import { useTheme } from '../utils/hooks/useTheme';
 import '@itwin/itwinui-css/css/toast-notification.css';
 import { IconButton } from '../Buttons';
+import { getWindow } from '../utils/common';
 
 export type ToastCategory = 'informational' | 'negative' | 'positive';
 
@@ -108,13 +109,18 @@ export const Toast = (props: ToastProps) => {
   };
 
   const setCloseTimeout = (timeout: number) => {
-    closeTimeout.current = window.setTimeout(() => {
+    const definedWindow = getWindow();
+    if (!definedWindow) {
+      return;
+    }
+
+    closeTimeout.current = definedWindow.setTimeout(() => {
       close();
     }, timeout);
   };
 
   const clearCloseTimeout = () => {
-    clearTimeout(closeTimeout.current);
+    getWindow()?.clearTimeout(closeTimeout.current);
   };
 
   const getCategoryIcon = React.useCallback(() => {

--- a/src/core/Toast/Toaster.tsx
+++ b/src/core/Toast/Toaster.tsx
@@ -65,10 +65,12 @@ export default class Toaster {
   }
 
   private updateView() {
-    ReactDOM.render(
-      <ToastWrapper toasts={this.toasts} />,
-      getContainer(TOASTS_CONTAINER_ID),
-    );
+    const container = getContainer(TOASTS_CONTAINER_ID);
+    if (!container) {
+      return;
+    }
+
+    ReactDOM.render(<ToastWrapper toasts={this.toasts} />, container);
   }
 
   public closeAll(): void {

--- a/src/core/utils/common.spec.tsx
+++ b/src/core/utils/common.spec.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { getContainer, getUserColor } from './common';
+import { getContainer, getDocument, getUserColor, getWindow } from './common';
 
 it('should return color for given user name', () => {
   expect(getUserColor('Terry Rivers')).toEqual('#6AB9EC');
@@ -28,4 +28,18 @@ it('should respect ownerDocument arg', () => {
   expect(mockDocument.getElementById('test-id')).toBeTruthy();
   expect(getContainer('test-id', mockDocument)).toBe(container);
   expect(getContainer('test-id', document)).not.toBe(container);
+});
+
+it('should get document when it is defined', () => {
+  expect(getDocument()).toBeTruthy();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  jest.spyOn(global as any, 'document', 'get').mockReturnValue(undefined);
+  expect(getDocument()).toBeFalsy();
+});
+
+it('should get window when it is defined', () => {
+  expect(getWindow()).toBeTruthy();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  jest.spyOn(global as any, 'window', 'get').mockReturnValue(undefined);
+  expect(getDocument()).toBeFalsy();
 });

--- a/src/core/utils/common.tsx
+++ b/src/core/utils/common.tsx
@@ -55,7 +55,7 @@ export const getContainer = (
   containerId: string,
   ownerDocument = getDocument(),
 ) => {
-  let container = ownerDocument?.getElementById(containerId);
+  let container = ownerDocument?.getElementById(containerId) ?? undefined;
   if (container == null && !!ownerDocument) {
     container = ownerDocument.createElement('div');
     container.setAttribute('id', containerId);

--- a/src/core/utils/common.tsx
+++ b/src/core/utils/common.tsx
@@ -51,9 +51,12 @@ export const getUserColor = (emailOrName: string) => {
  * @param containerId id of the container to find or create
  * @param ownerDocument Can be changed if the container should be in a different document (e.g. in popup).
  */
-export const getContainer = (containerId: string, ownerDocument = document) => {
-  let container = ownerDocument.getElementById(containerId);
-  if (container == null) {
+export const getContainer = (
+  containerId: string,
+  ownerDocument = getDocument(),
+) => {
+  let container = ownerDocument?.getElementById(containerId);
+  if (container == null && !!ownerDocument) {
     container = ownerDocument.createElement('div');
     container.setAttribute('id', containerId);
     ownerDocument.body.appendChild(container);

--- a/src/core/utils/common.tsx
+++ b/src/core/utils/common.tsx
@@ -60,3 +60,19 @@ export const getContainer = (containerId: string, ownerDocument = document) => {
   }
   return container;
 };
+
+/**
+ * Get document if it is defined.
+ * Used to support SSR/SSG applications.
+ */
+export const getDocument = () => {
+  return typeof document === 'undefined' ? undefined : document;
+};
+
+/**
+ * Get window if it is defined.
+ * Used to support SSR/SSG applications.
+ */
+export const getWindow = () => {
+  return typeof window === 'undefined' ? undefined : window;
+};

--- a/src/core/utils/hooks/useIntersection.tsx
+++ b/src/core/utils/hooks/useIntersection.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
+import { getWindow } from '../common';
 
 /**
  * Hook that uses `IntersectionObserver` to trigger `onIntersect` callback when element is in viewport.
@@ -24,7 +25,7 @@ export const useIntersection = (
 
   const setRef = React.useCallback(
     (node: HTMLElement | null) => {
-      if (!window.IntersectionObserver) {
+      if (!getWindow()?.IntersectionObserver) {
         return;
       }
 

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import '@itwin/itwinui-css/css/global.css';
-import { getWindow } from '../common';
+import { getDocument, getWindow } from '../common';
 
 export type ThemeOptions = {
   /**
@@ -27,19 +27,19 @@ export const useTheme = (
   theme?: ThemeType,
   themeOptions?: ThemeOptions,
 ): void => {
-  const getOwnerDocument = React.useCallback(() => {
-    return themeOptions?.ownerDocument ?? document;
-  }, [themeOptions?.ownerDocument]);
+  const ownerDocument = themeOptions?.ownerDocument ?? getDocument();
 
   React.useLayoutEffect(() => {
-    const ownerDocument = getOwnerDocument();
-    if (!ownerDocument.body.classList.contains('iui-body')) {
-      ownerDocument.body.classList.add('iui-body');
+    if (!ownerDocument?.body.classList.contains('iui-body')) {
+      ownerDocument?.body.classList.add('iui-body');
     }
-  }, [getOwnerDocument]);
+  }, [ownerDocument]);
 
   React.useLayoutEffect(() => {
-    const ownerDocument = getOwnerDocument();
+    if (!ownerDocument) {
+      return;
+    }
+
     switch (theme) {
       case 'light':
         addLightTheme(ownerDocument);
@@ -61,7 +61,7 @@ export const useTheme = (
           addLightTheme(ownerDocument);
         }
     }
-  }, [getOwnerDocument, theme]);
+  }, [ownerDocument, theme]);
 };
 
 const addLightTheme = (ownerDocument: Document) => {

--- a/src/core/utils/hooks/useTheme.ts
+++ b/src/core/utils/hooks/useTheme.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import '@itwin/itwinui-css/css/global.css';
+import { getWindow } from '../common';
 
 export type ThemeOptions = {
   /**
@@ -42,7 +43,7 @@ export const useTheme = (
         addDarkTheme(ownerDocument);
         break;
       case 'os':
-        if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
+        if (getWindow()?.matchMedia?.('(prefers-color-scheme: dark)').matches) {
           addDarkTheme(ownerDocument);
         } else {
           addLightTheme(ownerDocument);


### PR DESCRIPTION
After #99 SSR build was broken again. This time with document in FilterToggle.
Decided to replace all document/window with functions, where we check if those are defined (this is [recommended ](https://nextjs.org/docs/migrating/from-create-react-app#safely-accessing-web-apis) to do in SSR applications).


