### PR TITLE
Don't set tabindex=0 on selected `MenuItem`

### DIFF
--- a/src/core/Menu/MenuItem.test.tsx
+++ b/src/core/Menu/MenuItem.test.tsx
@@ -18,7 +18,7 @@ function assertBaseElement(
   } = {},
 ) {
   expect(menuItem).toBeTruthy();
-  expect(menuItem.tabIndex).toBe(isSelected ? 0 : -1);
+  expect(menuItem.getAttribute('tabindex')).toEqual(disabled ? null : '-1');
   expect(menuItem.getAttribute('role')).toEqual(role);
   expect(menuItem.classList.contains('iui-active')).toBe(isSelected);
   expect(menuItem.classList.contains('iui-disabled')).toBe(disabled);

--- a/src/core/Menu/MenuItem.tsx
+++ b/src/core/Menu/MenuItem.tsx
@@ -93,7 +93,7 @@ export const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(
         ref={ref}
         style={style}
         role={role}
-        tabIndex={disabled ? undefined : isSelected ? 0 : -1}
+        tabIndex={disabled ? undefined : -1}
         aria-selected={isSelected}
         onKeyDown={onKeyDown}
         {...rest}


### PR DESCRIPTION
Follow up to #107 to fix tab sequence in `Select`.

Also fixed test to correctly compare tabindex. The `tabIndex` property does not work correctly when `undefined`.