### PR TITLE
Refactored table select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+`Date`
+
+### Fixes
+
+- **Fixed a bug when `Table` sorting or filtering triggered `onSelect`.**
+
 ## [1.8.0]
 
 `2021-06-15`

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -203,6 +203,59 @@ it('should handle checkbox clicks', () => {
   expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
 });
 
+it('should not trigger onSelect when sorting and filtering', () => {
+  const onSort = jest.fn();
+  const onSelect = jest.fn();
+  const onFilter = jest.fn();
+  const mockedColumns = [
+    {
+      Header: 'Header name',
+      columns: [
+        {
+          id: 'name',
+          Header: 'Name',
+          accessor: 'name',
+          Filter: tableFilters.TextFilter(),
+          fieldType: 'text',
+        },
+      ],
+    },
+  ];
+  const { container } = renderComponent({
+    columns: mockedColumns,
+    isSortable: true,
+    onSelect,
+    onSort,
+    onFilter,
+  });
+
+  const nameHeader = container.querySelector(
+    '.iui-table-header .iui-cell',
+  ) as HTMLDivElement;
+  expect(nameHeader).toBeTruthy();
+  expect(nameHeader.classList).not.toContain('iui-sorted');
+
+  nameHeader.click();
+  expect(onSort).toHaveBeenCalled();
+  expect(onSelect).not.toHaveBeenCalled();
+
+  const filterIcon = container.querySelector(
+    '.iui-filter-button .iui-icon',
+  ) as HTMLElement;
+  expect(filterIcon).toBeTruthy();
+  fireEvent.click(filterIcon);
+
+  const filterInput = document.querySelector(
+    '.iui-column-filter input',
+  ) as HTMLInputElement;
+  expect(filterInput).toBeTruthy();
+
+  fireEvent.change(filterInput, { target: { value: '2' } });
+  screen.getByText('Filter').click();
+  expect(onFilter).toHaveBeenCalled();
+  expect(onSelect).not.toHaveBeenCalled();
+});
+
 it('should not show sorting icon if sorting is disabled', () => {
   const { container } = renderComponent({
     isSortable: false,


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes issue #141 

## Checklist

- [x] Add meaningful tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [x] Add an entry to the changelog for any new components and changes
- [ ] Add screenshots of the key elements of the component
- [x] Add any additional comments describing the features you've implemented

Manually handling selected rows as previously sorting or filtering would trigger `onSelect` callback because I think `selectedFlatRows` reference changes every time and triggers `onSelect`.
