### PR TITLE
Release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### What's new
 
 - **Added expanding functionality for `Table`.** Provide `subComponent` prop.
+- **Updated styling for `HorizontalTabs`.**
+- **Added ability to control opening `Select` menu.** Provide `visible` in `popoverProps` prop.
 - **Improved `Table` documentation.**
 
 ## [1.9.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## [1.10.0]
 
-`2021-06-XX`
+`2021-07-01`
 
 ### What's new
 
@@ -371,6 +371,7 @@
 - **New ThemeProvider component added.** It allows to switch between light and dark themes.
 - **iTwinUI-React is generated to `CommonJS` and `ES` modules.** Usage of `ES` modules allows bundlers to tree-shake unused code resulting in smaller bundle sizes.
 
+[1.10.0]: https://github.com/iTwin/iTwinUI-react/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/iTwin/iTwinUI-react/compare/v1.8.1...v1.9.0
 [1.8.1]: https://github.com/iTwin/iTwinUI-react/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/iTwin/iTwinUI-react/compare/v1.7.2...v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### What's new
 
 - **Added expanding functionality for `Table`.** Provide `subComponent` prop.
-- **Updated styling for `HorizontalTabs`.**
 - **Added ability to control opening `Select` menu.** Provide `visible` in `popoverProps` prop.
+- **Updated styling for `HorizontalTabs`** through base CSS package.
 - **Improved `Table` documentation.**
 
 ## [1.9.0]

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "^0.22.0",
+    "@itwin/itwinui-css": "^0.22.1",
     "@itwin/itwinui-icons-react": "^1.1.1",
     "@itwin/itwinui-illustrations-react": "^1.0.1",
     "@tippyjs/react": "^4.2.5",

--- a/stories/core/HorizontalTabs.stories.tsx
+++ b/stories/core/HorizontalTabs.stories.tsx
@@ -49,7 +49,7 @@ BorderlessTabs.args = {
 export const PillTabs = Template.bind({});
 PillTabs.args = {
   labels: [...new Array(3)].map((_, index) => (
-    <SvgStar key={index} aria-hidden className='iui-tab-icon' />
+    <SvgStar key={index} aria-hidden />
   )),
   type: 'pill',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,10 +1606,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.22.0.tgz#f57c02dfd6541e0e22bc6775ec50d926ec6c94a3"
-  integrity sha512-f3W+wR0onoO8ucat+x2931JvDztaxKeim0WiMkTSvjd2VzixJBH6H51pLT2R/1KHhPdhNHwobT2kVAviab7RFA==
+"@itwin/itwinui-css@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.22.1.tgz#844cfd9b48c8a8c3afa5eb6ce16c31ebff0b33ad"
+  integrity sha512-PMRtv7dFyrLlL+RnlICj2OlQSDyzv+HdlfianSXlfFuOkb833fKJ5wM3fKvdyHGCkNrnkpgwM/CYZ41Zjt4FvA==
 
 "@itwin/itwinui-icons-react@^1.1.1":
   version "1.1.3"


### PR DESCRIPTION
Release 1.10 +
- Bumped itwinui-css to 0.22.1
- Removed classname `HorizontalTabs` pill story using the css fix