### PR TITLE
Disable extra Table props in storybook

### DIFF
--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -65,6 +65,8 @@ export default {
     autoResetSortBy: { table: { disable: true } },
     autoResetHiddenColumns: { table: { disable: true } },
     autoResetFilters: { table: { disable: true } },
+    filterTypes: { table: { disable: true } },
+    defaultCanFilter: { table: { disable: true } },
     manualFilters: { table: { disable: true } },
     paginateExpandedRows: { table: { disable: true } },
     expandSubRows: { table: { disable: true } },

--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -39,78 +39,37 @@ export default {
     emptyTableContent: 'No data.',
   },
   argTypes: {
-    columns: {
-      control: { disable: true },
-    },
-    isSelectable: {
-      control: { disable: true },
-    },
-    style: {
-      control: { disable: true },
-    },
-    className: {
-      control: { disable: true },
-    },
-    initialState: {
-      table: { disable: true },
-    },
-    stateReducer: {
-      table: { disable: true },
-    },
-    useControlledState: {
-      table: { disable: true },
-    },
-    defaultColumn: {
-      table: { disable: true },
-    },
-    getSubRows: {
-      table: { disable: true },
-    },
-    getRowId: {
-      table: { disable: true },
-    },
-    manualRowSelectedKey: {
-      table: { disable: true },
-    },
-    autoResetSelectedRows: {
-      table: { disable: true },
-    },
-    selectSubRows: {
-      table: { disable: true },
-    },
-    manualSortBy: {
-      table: { disable: true },
-    },
-    defaultCanSort: {
-      table: { disable: true },
-    },
-    disableMultiSort: {
-      table: { disable: true },
-    },
-    isMultiSortEvent: {
-      table: { disable: true },
-    },
-    maxMultiSortColCount: {
-      table: { disable: true },
-    },
-    disableSortRemove: {
-      table: { disable: true },
-    },
-    disabledMultiRemove: {
-      table: { disable: true },
-    },
-    orderByFn: {
-      table: { disable: true },
-    },
-    sortTypes: {
-      table: { disable: true },
-    },
-    autoResetSortBy: {
-      table: { disable: true },
-    },
-    autoResetHiddenColumns: {
-      table: { disable: true },
-    },
+    columns: { control: { disable: true } },
+    isSelectable: { control: { disable: true } },
+    style: { control: { disable: true } },
+    className: { control: { disable: true } },
+    id: { control: { disable: true } },
+    initialState: { table: { disable: true } },
+    stateReducer: { table: { disable: true } },
+    useControlledState: { table: { disable: true } },
+    defaultColumn: { table: { disable: true } },
+    getSubRows: { table: { disable: true } },
+    getRowId: { table: { disable: true } },
+    manualRowSelectedKey: { table: { disable: true } },
+    autoResetSelectedRows: { table: { disable: true } },
+    selectSubRows: { table: { disable: true } },
+    manualSortBy: { table: { disable: true } },
+    defaultCanSort: { table: { disable: true } },
+    disableMultiSort: { table: { disable: true } },
+    isMultiSortEvent: { table: { disable: true } },
+    maxMultiSortColCount: { table: { disable: true } },
+    disableSortRemove: { table: { disable: true } },
+    disabledMultiRemove: { table: { disable: true } },
+    orderByFn: { table: { disable: true } },
+    sortTypes: { table: { disable: true } },
+    autoResetSortBy: { table: { disable: true } },
+    autoResetHiddenColumns: { table: { disable: true } },
+    autoResetFilters: { table: { disable: true } },
+    manualFilters: { table: { disable: true } },
+    paginateExpandedRows: { table: { disable: true } },
+    expandSubRows: { table: { disable: true } },
+    autoResetExpanded: { table: { disable: true } },
+    manualExpandedKey: { table: { disable: true } },
   },
   parameters: {
     creevey: { skip: { stories: ['Lazy Loading', 'Row In Viewport'] } },


### PR DESCRIPTION
Noticed a bunch of extra controls in Table in the newly released Storybook. https://itwin.github.io/iTwinUI-react/?path=/story/core-table
![image](https://user-images.githubusercontent.com/9084735/124159962-bbac8900-da69-11eb-8a6b-7f2594314de6.png)

Disabled them and formatted them to take up less space.