### PR TITLE
Make Tooltip `children` optional

### DIFF
--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -30,8 +30,8 @@ export type TooltipProps = {
  * @example
  * const buttonRef = React.useRef();
  * ...
- * <Tooltip content='tooltip text' reference={buttonRef} />
  * <Button ref={buttonRef} />
+ * <Tooltip content='tooltip text' reference={buttonRef.current} />
  */
 export const Tooltip = (props: TooltipProps) => {
   const {

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -15,9 +15,10 @@ export type TooltipProps = {
    */
   content: React.ReactNode;
   /**
-   * Element to have tooltip on. Has to be valid JSX element.
+   * Element to have tooltip on. Has to be a valid JSX element and needs to forward its ref.
+   * If not specified, the `reference` prop should be used instead.
    */
-  children: JSX.Element;
+  children?: JSX.Element;
 } & Omit<PopoverProps, 'className'> &
   Omit<CommonProps, 'title'>;
 
@@ -26,6 +27,11 @@ export type TooltipProps = {
  * Uses the {@link Popover} component, which is a wrapper around [tippy.js](https://atomiks.github.io/tippyjs).
  * @example
  * <Tooltip content='tooltip text' placement='top'><div>Hover here</div></Tooltip>
+ * @example
+ * const buttonRef = React.useRef();
+ * ...
+ * <Tooltip content='tooltip text' reference={buttonRef} />
+ * <Button ref={buttonRef} />
  */
 export const Tooltip = (props: TooltipProps) => {
   const {

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -65,7 +65,7 @@ export const Tooltip = (props: TooltipProps) => {
       ref={ref}
       {...rest}
     >
-      {React.cloneElement(children, { title: undefined })}
+      {children && React.cloneElement(children, { title: undefined })}
     </Popover>
   );
 };


### PR DESCRIPTION
Made `Tooltip` children optional and updated JSDoc comment to give an example of the `reference` prop.

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add an entry to the changelog for any new components and changes
- [ ] Add screenshots of the key elements of the component
- [ ] Add any additional comments describing the features you've implemented
