### PR TITLE
Update documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,24 +12,19 @@ Make sure you first do a search for existing issues so that is not a duplicate.
 Also go through our FAQ: https://github.com/iTwin/iTwinUI-react/wiki/FAQ
 -->
 
-#### Environment
-- __Package version(s)__: <!-- fill this out -->
-- __Operating System__: <!-- fill this out -->
-- __Browser name and version__: <!-- fill this out -->
-
-#### Code Sandbox
-Link to a minimal repro: <!-- fork this sandbox: https://codesandbox.io/s/itwinui-react-example-son74 -->
-
-#### Steps to reproduce
-1. <!-- fill this out -->
-1. <!-- fill this out -->
-1. <!-- fill this out -->
-
-#### Actual behavior
+#### Describe the bug (actual behavior)
 <!-- A clear and concise description of what the bug is. -->
 
 #### Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
+#### Reproduction
+Link to a minimal repro: <!-- fork this sandbox: https://codesandbox.io/s/itwinui-react-example-son74 -->
+
+##### Steps to reproduce
+1. <!-- fill this out -->
+1. <!-- fill this out -->
+1. <!-- fill this out -->
+
 #### Additional information
-<!-- Add anything else you want to mention (additional context, possible solution, etc) -->
+<!-- Add anything else you want to mention (package version, environment info, possible solution, etc) -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,22 +148,13 @@ parameters: {
 
 If you want to test your changes in a local project, you can go into the `lib/` folder (which gets created when running `yarn build` or `yarn build:watch`) and run `yarn link`. Then from your test project, run `yarn link @itwin/itwinui-react`.
 
-You might face an "invalid hook call" error if your test project is using a different version or instance of React. You can fix this by [linking React](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) or by using [aliases](https://github.com/facebook/react/issues/13991#issuecomment-463486871) in your bundler. If it still doesn't work, you may consider using `yalc`.
+You might face an "invalid hook call" error if your test project is using a different version or instance of React. You can fix this by [linking React](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) or by using [aliases](https://github.com/facebook/react/issues/13991#issuecomment-463486871) in your bundler. If it still doesn't work, you may consider using [`yalc`](https://github.com/wclr/yalc) instead.
 
-<details>
-<summary>Yalc instructions (untested)</summary>
-You may want to install `yalc`, `concurrently`, and `nodemon` or `chokidar-cli` globally to compile and push changes to another project linked to iTwinUI-react.
-Add these scripts to package.json:
-<pre>
-  "watch": "concurrently --kill-others \"yarn watch:tsx\" \"yarn watch:yalc:push\"",
-  "watch:tsx": "tsc --watch",
-  "watch:yalc:push": "delay 20 && cd lib && nodemon -e js,ts,tsx,d.ts -x \"yalc push\"",
-</pre>
-Chokidar version:
-<pre>
-  "watch:yalc:push": "delay 20 && cd lib && chokidar \"**/*.js\" \"**/*.ts\" \"**/*.tsx\" \"**/*.d.ts\" -c \"yalc push\"",
-</pre>
-</details>
+#### Yalc instructions
+
+Install yalc globally (`yarn global add yalc`) and run `yalc publish` from the `lib/` folder. Then from your test project, run `yalc add @itwin/itwinui-react`.
+
+Every time you rebuild iTwinUI-react, you will need to run `yalc push`. You might want to automate this with a custom script using `chokidar-cli` or `nodemon`.
 
 ### Changelog
 

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -31,7 +31,7 @@ export type TooltipProps = {
  * const buttonRef = React.useRef();
  * ...
  * <Button ref={buttonRef} />
- * <Tooltip content='tooltip text' reference={buttonRef.current} />
+ * <Tooltip content='tooltip text' reference={buttonRef} />
  */
 export const Tooltip = (props: TooltipProps) => {
   const {


### PR DESCRIPTION
- Simplified bug_report.md, with the goal of making it less daunting for users to open issues.
- Updated CONTRIBUTING.md to add simpler instructions for [`yalc`](https://github.com/wclr/yalc).
  - In practice, yalc always works more reliably than `yarn link` so these instructions will help contributors.
  - Removed the watch script instructions, as they add too much noise and detract from the important parts.
- Fixed wrong example in Tooltip JSDoc.