### PR TITLE
Fix default values in storybook

### DIFF
--- a/stories/core/Alert.stories.tsx
+++ b/stories/core/Alert.stories.tsx
@@ -15,6 +15,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     onClick: { control: { disable: true } },
     onClose: { control: { disable: true } },
     clickableText: { type: 'string' },

--- a/stories/core/Badge.stories.tsx
+++ b/stories/core/Badge.stories.tsx
@@ -11,6 +11,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     backgroundColor: { control: 'color' },
   },
   title: 'Core/Badge',

--- a/stories/core/DatePicker.stories.tsx
+++ b/stories/core/DatePicker.stories.tsx
@@ -22,6 +22,7 @@ export default {
     onChange: { control: { disable: true } },
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     date: { control: 'date' },
   },
   args: {

--- a/stories/core/ErrorPage.stories.tsx
+++ b/stories/core/ErrorPage.stories.tsx
@@ -12,6 +12,7 @@ export default {
   title: 'Core/ErrorPage',
   component: ErrorPage,
   argTypes: {
+    id: { control: { disable: true } },
     errorType: {
       type: { required: true },
     },

--- a/stories/core/ExpandableBlock.stories.tsx
+++ b/stories/core/ExpandableBlock.stories.tsx
@@ -19,6 +19,7 @@ export default {
     },
     style: { control: { disable: true } },
     className: { control: { disable: true } },
+    id: { control: { disable: true } },
   },
   args: {
     children: 'Content in block!',

--- a/stories/core/FileUpload.stories.tsx
+++ b/stories/core/FileUpload.stories.tsx
@@ -18,6 +18,8 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    title: { control: { disable: true } },
+    id: { control: { disable: true } },
     onFileDropped: { control: { disable: true } },
     children: { control: { disable: true } },
   },

--- a/stories/core/Footer.stories.tsx
+++ b/stories/core/Footer.stories.tsx
@@ -13,6 +13,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
   },
 } as Meta<FooterProps>;
 

--- a/stories/core/Header.stories.tsx
+++ b/stories/core/Header.stories.tsx
@@ -43,6 +43,7 @@ export default {
     children: { control: { disable: true } },
     style: { control: { disable: true } },
     className: { control: { disable: true } },
+    id: { control: { disable: true } },
   },
   parameters: {
     creevey: {
@@ -73,6 +74,7 @@ const buildMenu = (menu: string) => (close: () => void) => [
 export const Full: Story<HeaderProps> = (args) => {
   return (
     <Header
+      {...args}
       appLogo={
         <HeaderLogo
           logo={
@@ -150,7 +152,6 @@ export const Full: Story<HeaderProps> = (args) => {
         </DropdownMenu>
       }
       menuItems={buildMenu('More')}
-      {...args}
     />
   );
 };
@@ -158,6 +159,7 @@ export const Full: Story<HeaderProps> = (args) => {
 export const Basic: Story<HeaderProps> = (args) => {
   return (
     <Header
+      {...args}
       appLogo={
         <HeaderLogo
           logo={
@@ -210,7 +212,6 @@ export const Basic: Story<HeaderProps> = (args) => {
           title='Terry Rivers'
         />
       }
-      {...args}
     />
   );
 };
@@ -220,7 +221,8 @@ export const CenterContent: Story<HeaderProps> = (args) => {
     <>
       <style>
         {`.center-input { border-radius: 22px; width: 20vw; transition: all 0.2s ease }`}
-        {`.iui-slim .center-input { padding-top: 0; padding-bottom: 0; }`}
+        {`.iui-slim .iui-center { align-items: unset }`}
+        {`.iui-slim .center-input { min-height: unset }`}
         {`@media (max-width: 768px) { .center-input { display: none; } }`}
       </style>
       <Input className='center-input' placeholder='Search within Model B...' />
@@ -229,6 +231,7 @@ export const CenterContent: Story<HeaderProps> = (args) => {
 
   return (
     <Header
+      {...args}
       appLogo={<HeaderLogo logo={<SvgImodel />} />}
       breadcrumbs={
         <HeaderBreadcrumbs
@@ -270,7 +273,6 @@ export const CenterContent: Story<HeaderProps> = (args) => {
         />
       }
       menuItems={buildMenu('More')}
-      {...args}
     >
       {searchBar}
     </Header>

--- a/stories/core/HorizontalTabs.stories.tsx
+++ b/stories/core/HorizontalTabs.stories.tsx
@@ -46,6 +46,7 @@ const Template: Story<HorizontalTabsProps> = (args) => {
 
 export const DefaultTabs = Template.bind({});
 DefaultTabs.args = {
+  type: 'default',
   labels: [
     <HorizontalTab key={1} label='Item1' />,
     <HorizontalTab key={2} label='Item2' />,

--- a/stories/core/HorizontalTabs.stories.tsx
+++ b/stories/core/HorizontalTabs.stories.tsx
@@ -38,7 +38,7 @@ const Template: Story<HorizontalTabsProps> = (args) => {
     }
   };
   return (
-    <HorizontalTabs onTabSelected={setIndex} {...args}>
+    <HorizontalTabs {...args} onTabSelected={setIndex}>
       {getContent()}
     </HorizontalTabs>
   );

--- a/stories/core/InputGroup.stories.tsx
+++ b/stories/core/InputGroup.stories.tsx
@@ -19,6 +19,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     svgIcon: { control: { disable: true } },
   },
 } as Meta<InputGroupProps>;

--- a/stories/core/Modal.stories.tsx
+++ b/stories/core/Modal.stories.tsx
@@ -21,6 +21,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     onClose: { control: { disable: true } },
     ownerDocument: { control: { disable: true } },
   },

--- a/stories/core/ProgressLinear.stories.tsx
+++ b/stories/core/ProgressLinear.stories.tsx
@@ -13,6 +13,12 @@ import { ProgressLinearProps } from '../../src/core/ProgressIndicators/ProgressL
 export default {
   title: 'ProgressIndicators/ProgressLinear',
   component: ProgressLinear,
+  argTypes: {
+    className: { control: { disable: true } },
+    style: { control: { disable: true } },
+    title: { control: { disable: true } },
+    id: { control: { disable: true } },
+  },
 } as Meta<ProgressLinearProps>;
 
 export const Determinate: Story<ProgressLinearProps> = (args) => {

--- a/stories/core/ProgressRadial.stories.tsx
+++ b/stories/core/ProgressRadial.stories.tsx
@@ -10,6 +10,12 @@ import { ProgressRadialProps } from '../../src/core/ProgressIndicators/ProgressR
 export default {
   title: 'ProgressIndicators/ProgressRadial',
   component: ProgressRadial,
+  argTypes: {
+    className: { control: { disable: true } },
+    style: { control: { disable: true } },
+    title: { control: { disable: true } },
+    id: { control: { disable: true } },
+  },
   args: {
     value: 50,
   },

--- a/stories/core/Select.stories.tsx
+++ b/stories/core/Select.stories.tsx
@@ -72,11 +72,11 @@ export const Basic: Story<SelectProps<number>> = (args) => {
   return (
     <div style={{ minHeight: 350 }}>
       <Select<number>
+        {...rest}
         options={options}
         value={value}
         onChange={setValue}
         placeholder={placeholder}
-        {...rest}
       />
     </div>
   );
@@ -105,11 +105,11 @@ export const WithIcons: Story<SelectProps<string>> = (args) => {
   return (
     <div style={{ minHeight: 350 }}>
       <Select<string>
+        {...rest}
         options={options}
         value={value}
         onChange={setValue}
         placeholder={placeholder}
-        {...rest}
       />
     </div>
   );
@@ -202,6 +202,7 @@ export const ManyItems: Story<SelectProps<number>> = (args) => {
   return (
     <div style={{ minHeight: 350 }}>
       <Select<number>
+        {...rest}
         options={
           options ||
           [...Array(20).fill(null)].map((_, index) => ({
@@ -212,7 +213,6 @@ export const ManyItems: Story<SelectProps<number>> = (args) => {
         value={value}
         onChange={setValue}
         placeholder={placeholder}
-        {...rest}
       />
     </div>
   );
@@ -241,12 +241,12 @@ export const Sublabels: Story<SelectProps<number>> = (args) => {
   return (
     <div style={{ minHeight: 350 }}>
       <Select<number>
+        {...rest}
         options={options}
         value={value}
         onChange={setValue}
         placeholder={placeholder}
         size={size}
-        {...rest}
       />
     </div>
   );
@@ -278,6 +278,7 @@ export const Custom: Story<SelectProps<string>> = (args) => {
   return (
     <div style={{ minHeight: 350 }}>
       <Select<string>
+        {...rest}
         options={options}
         value={selectedValue}
         onChange={setSelectedValue}
@@ -288,7 +289,6 @@ export const Custom: Story<SelectProps<string>> = (args) => {
         selectedItemRenderer={(option) => (
           <span style={{ backgroundColor: option.value }}>{option.label}</span>
         )}
-        {...rest}
       />
     </div>
   );

--- a/stories/core/Select.stories.tsx
+++ b/stories/core/Select.stories.tsx
@@ -18,6 +18,7 @@ export default {
   argTypes: {
     style: { control: { disable: true } },
     className: { control: { disable: true } },
+    id: { control: { disable: true } },
     menuStyle: { control: { disable: true } },
     menuClassName: { control: { disable: true } },
   },

--- a/stories/core/SideNavigation.stories.tsx
+++ b/stories/core/SideNavigation.stories.tsx
@@ -24,6 +24,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     items: { control: { disable: true } },
     secondaryItems: { control: { disable: true } },
   },

--- a/stories/core/Slider.stories.tsx
+++ b/stories/core/Slider.stories.tsx
@@ -12,6 +12,15 @@ import SvgSmileySad from '@itwin/itwinui-icons-react/cjs/icons/SmileySad';
 export default {
   title: 'Input/Slider',
   component: Slider,
+  argTypes: {
+    className: { control: { disable: true } },
+    style: { control: { disable: true } },
+    id: { control: { disable: true } },
+  },
+  args: {
+    thumbMode: 'inhibit-crossing',
+    trackDisplayMode: 'auto',
+  },
 } as Meta<SliderProps>;
 
 export const Basic: Story<SliderProps> = (args) => {

--- a/stories/core/Tags/Tag.stories.tsx
+++ b/stories/core/Tags/Tag.stories.tsx
@@ -12,6 +12,11 @@ export default {
   argTypes: {
     style: { control: { disable: true } },
     className: { control: { disable: true } },
+    title: { control: { disable: true } },
+    id: { control: { disable: true } },
+  },
+  args: {
+    variant: 'default',
   },
 } as Meta<TagProps>;
 

--- a/stories/core/Tags/TagContainer.stories.tsx
+++ b/stories/core/Tags/TagContainer.stories.tsx
@@ -12,6 +12,7 @@ export default {
   argTypes: {
     style: { table: { disable: true } },
     className: { table: { disable: true } },
+    id: { control: { disable: true } },
     children: { control: { disable: true } },
   },
 } as Meta<TagContainerProps>;

--- a/stories/core/Tile.stories.tsx
+++ b/stories/core/Tile.stories.tsx
@@ -30,6 +30,9 @@ export default {
     style: { control: { disable: true } },
     id: { control: { disable: true } },
   },
+  args: {
+    variant: 'default',
+  },
   title: 'Core/Tile',
 } as Meta<TileProps>;
 

--- a/stories/core/Tile.stories.tsx
+++ b/stories/core/Tile.stories.tsx
@@ -28,6 +28,7 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
   },
   title: 'Core/Tile',
 } as Meta<TileProps>;

--- a/stories/core/TimePicker.stories.tsx
+++ b/stories/core/TimePicker.stories.tsx
@@ -23,6 +23,7 @@ export default {
     onChange: { control: { disable: true } },
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
     date: { control: { type: 'date' } },
   },
   parameters: {

--- a/stories/core/Tooltip.stories.tsx
+++ b/stories/core/Tooltip.stories.tsx
@@ -30,6 +30,7 @@ export default {
     visible: { control: { type: 'boolean' } },
     className: { control: { disable: true } },
     style: { control: { disable: true } },
+    id: { control: { disable: true } },
   },
   parameters: {
     creevey: {


### PR DESCRIPTION
- Fixed Header, HorizontalTabs and Select stories by moving args from end to beginning.
  - This prevents them from getting overridden by `undefined`.
- Fixed center input styling in slim header.
- Disabled `id` control in some places.
- Added missing default values for args in some places (no longer inferred).