### PR TITLE
Make Button `children` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+`Date`
+
+### Fixes
+
+- **Made `Button` children optional** to allow using buttons with only icons.
+
 ## [1.12.0]
 
 `2021-07-20`

--- a/src/core/Buttons/Button/Button.test.tsx
+++ b/src/core/Buttons/Button/Button.test.tsx
@@ -139,3 +139,22 @@ it('should render with icon correctly', () => {
   const label = container.querySelector('.iui-icon + .iui-label')?.textContent;
   expect(label).toEqual('Click me!');
 });
+
+it('should render without label correctly', () => {
+  const { container } = render(
+    <Button startIcon={<SvgPlaceholder />} endIcon={<SvgPlaceholder />} />,
+  );
+
+  const button = container.querySelector('.iui-button') as HTMLButtonElement;
+  expect(button).toBeTruthy();
+  expect(button.textContent).toBeFalsy();
+  expect(button.querySelector('.iui-label')).toBeFalsy();
+
+  const {
+    container: { firstChild: placeholderIcon },
+  } = render(<SvgPlaceholder className='iui-icon' />);
+
+  button.querySelectorAll('.iui-icon').forEach((button) => {
+    expect(button).toEqual(placeholderIcon);
+  });
+});

--- a/src/core/Buttons/Button/Button.test.tsx
+++ b/src/core/Buttons/Button/Button.test.tsx
@@ -154,7 +154,7 @@ it('should render without label correctly', () => {
     container: { firstChild: placeholderIcon },
   } = render(<SvgPlaceholder className='iui-icon' />);
 
-  button.querySelectorAll('.iui-icon').forEach((button) => {
-    expect(button).toEqual(placeholderIcon);
+  button.querySelectorAll('.iui-icon').forEach((icon) => {
+    expect(icon).toEqual(placeholderIcon);
   });
 });

--- a/src/core/Buttons/Button/Button.tsx
+++ b/src/core/Buttons/Button/Button.tsx
@@ -30,7 +30,7 @@ export type ButtonProps = {
   /**
    * Content of the button.
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 /**
@@ -78,7 +78,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             className: cx('iui-icon', startIcon.props.className),
           })}
 
-        <span className='iui-label'>{children}</span>
+        {children && <span className='iui-label'>{children}</span>}
 
         {endIcon &&
           React.cloneElement(endIcon, {


### PR DESCRIPTION
`children` is optional to allow buttons with only icons (no labels).
![image](https://user-images.githubusercontent.com/9084735/127167413-dfaed37b-05e6-4a2d-9f57-16c6fad59313.png)

Closes #218

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [x] Add an entry to the changelog for any new components and changes
- [x] Add screenshots of the key elements of the component
- [x] Add any additional comments describing the features you've implemented
