### PR TITLE
Fix  slider thumb focus issue by reverting to using index as key

### DIFF
--- a/src/core/Slider/Slider.test.tsx
+++ b/src/core/Slider/Slider.test.tsx
@@ -283,7 +283,7 @@ it('should process keystrokes when thumb has focus', () => {
     <Slider values={[50]} step={5} setFocus onChange={handleOnChange} />,
   );
   assertBaseElement(container);
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
 
   expect(document.activeElement).toEqual(thumb);
@@ -292,45 +292,40 @@ it('should process keystrokes when thumb has focus', () => {
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('45');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowDown' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('40');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowRight' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('45');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowUp' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('50');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'Home' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('0');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'End' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('100');
   expect(handleOnChange).toHaveBeenCalledTimes(6);
+  expect(document.activeElement).toEqual(thumb);
 });
 
 it('should limit keystrokes processing to adjacent points by default', () => {
   const { container } = render(<Slider values={[40, 80]} step={5} setFocus />);
   assertBaseElement(container);
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
 
   expect(document.activeElement).toEqual(thumb);
@@ -339,25 +334,21 @@ it('should limit keystrokes processing to adjacent points by default', () => {
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('35');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowRight' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('40');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'Home' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('0');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'End' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('75');
 });
 
@@ -373,7 +364,7 @@ it('should limit keystrokes processing by min max when allow-crossing is set', (
     />,
   );
   assertBaseElement(container);
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
 
   expect(document.activeElement).toEqual(thumb);
@@ -382,25 +373,21 @@ it('should limit keystrokes processing by min max when allow-crossing is set', (
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('35');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowRight' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('40');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'Home' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('0');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'End' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('100');
   expect(handleOnChange).toHaveBeenCalledTimes(4);
 
@@ -414,21 +401,20 @@ it('should limit keystrokes processing by min max when allow-crossing is set', (
 it('should not process keystrokes when slider is disabled', () => {
   const { container } = render(<Slider values={[50]} step={5} disabled />);
   assertBaseElement(container);
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb).toBeTruthy();
   expect(thumb.classList).not.toContain('iui-active');
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.getAttribute('aria-valuenow')).toEqual('50');
 });
 
 it('should show tooltip on thumb hover', () => {
   const { container } = render(<Slider values={defaultSingleValue} />);
   assertBaseElement(container);
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
   expect(container.querySelector('.iui-tooltip')).toBeFalsy();
 
@@ -438,7 +424,6 @@ it('should show tooltip on thumb hover', () => {
   expect(container.querySelector('.iui-tooltip')?.textContent).toBe('50');
 
   act(() => {
-    thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
     fireEvent.mouseLeave(thumb);
   });
   const tippy = container.querySelector('[data-tippy-root]') as HTMLElement;
@@ -448,7 +433,7 @@ it('should show tooltip on thumb hover', () => {
 it('should show tooltip on thumb focus', () => {
   const { container } = render(<Slider values={defaultSingleValue} />);
   assertBaseElement(container);
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
   expect(container.querySelector('.iui-tooltip')).toBeFalsy();
 
@@ -460,7 +445,6 @@ it('should show tooltip on thumb focus', () => {
   ).toBe('50');
 
   act(() => {
-    thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
     thumb.blur();
   });
   const tippy = container.querySelector('[data-tippy-root]') as HTMLElement;
@@ -623,7 +607,7 @@ it('should activate thumb on pointerDown and move to closest step on move', () =
   const sliderContainer = container.querySelector(
     '.iui-slider-container',
   ) as HTMLDivElement;
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
 
   act(() => {
@@ -633,7 +617,6 @@ it('should activate thumb on pointerDown and move to closest step on move', () =
       clientX: 210,
     });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).toContain('iui-active');
 
   // moving to same location should not trigger update
@@ -686,7 +669,7 @@ it('should activate thumb on pointerDown and move to closest step on move/ no up
   const sliderContainer = container.querySelector(
     '.iui-slider-container',
   ) as HTMLDivElement;
-  let thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb).toBeTruthy();
   expect(thumb.classList).not.toContain('iui-active');
 
@@ -697,7 +680,6 @@ it('should activate thumb on pointerDown and move to closest step on move/ no up
       clientX: 210,
     });
   });
-  thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).toContain('iui-active');
   expect(sliderContainer.classList).toContain('iui-grabbing');
 

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -442,7 +442,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
             const thisThumbProps = thumbProps?.(index) ?? {};
             return (
               <Thumb
-                key={`${thisThumbProps?.id ?? index}`}
+                key={`${thisThumbProps.id ?? index}`}
                 index={index}
                 disabled={disabled}
                 isActive={activeThumbIndex === index}

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -439,10 +439,10 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
           <div className='iui-slider-rail' />
           {currentValues.map((thumbValue, index) => {
             const [minVal, maxVal] = getAllowableThumbRange(index);
-            const thisThumbProps = thumbProps?.(index) ?? {};
+            const thisThumbProps = thumbProps?.(index);
             return (
               <Thumb
-                key={`${thisThumbProps.id ?? index}`}
+                key={thisThumbProps?.id ?? index}
                 index={index}
                 disabled={disabled}
                 isActive={activeThumbIndex === index}

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -205,12 +205,9 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
       ...rest
     } = props;
 
-    const thumbIdRef = React.useRef(0);
-
     const [currentValues, setCurrentValues] = React.useState(values);
     React.useEffect(() => {
       setCurrentValues(values);
-      thumbIdRef.current = thumbIdRef.current + 1;
     }, [values]);
 
     const [minValueLabel, setMinValueLabel] = React.useState(
@@ -444,7 +441,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
             const [minVal, maxVal] = getAllowableThumbRange(index);
             return (
               <Thumb
-                key={`${thumbIdRef.current}-${index}`}
+                key={index}
                 index={index}
                 disabled={disabled}
                 isActive={activeThumbIndex === index}

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -440,12 +440,9 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
           {currentValues.map((thumbValue, index) => {
             const [minVal, maxVal] = getAllowableThumbRange(index);
             const thisThumbProps = thumbProps?.(index) ?? {};
-            const key = thisThumbProps.id
-              ? thisThumbProps.id
-              : index.toString();
             return (
               <Thumb
-                key={key}
+                key={`${thisThumbProps?.id ?? index}`}
                 index={index}
                 disabled={disabled}
                 isActive={activeThumbIndex === index}

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -439,9 +439,13 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
           <div className='iui-slider-rail' />
           {currentValues.map((thumbValue, index) => {
             const [minVal, maxVal] = getAllowableThumbRange(index);
+            const thisThumbProps = thumbProps?.(index) ?? {};
+            const key = thisThumbProps.id
+              ? thisThumbProps.id
+              : index.toString();
             return (
               <Thumb
-                key={index}
+                key={key}
                 index={index}
                 disabled={disabled}
                 isActive={activeThumbIndex === index}
@@ -451,7 +455,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
                 maxVal={maxVal}
                 value={thumbValue}
                 tooltipProps={generateTooltipProps(index, thumbValue)}
-                thumbProps={thumbProps}
+                thumbProps={thisThumbProps}
                 step={step}
                 sliderMin={min}
                 sliderMax={max}

--- a/src/core/Slider/Thumb.tsx
+++ b/src/core/Slider/Thumb.tsx
@@ -58,7 +58,7 @@ export type ThumbProps = {
   /**
    * Additional props for Thumb.
    */
-  thumbProps: React.HTMLAttributes<HTMLDivElement>;
+  thumbProps?: React.HTMLAttributes<HTMLDivElement>;
 };
 
 /**
@@ -116,7 +116,7 @@ export const Thumb = (props: ThumbProps) => {
   const [isHovered, setIsHovered] = React.useState(false);
 
   const leftPercent = (100.0 * (value - sliderMin)) / (sliderMax - sliderMin);
-  const { style, className, ...rest } = thumbProps;
+  const { style, className, ...rest } = thumbProps || {};
 
   return (
     <Tooltip

--- a/src/core/Slider/Thumb.tsx
+++ b/src/core/Slider/Thumb.tsx
@@ -58,7 +58,7 @@ export type ThumbProps = {
   /**
    * Additional props for Thumb.
    */
-  thumbProps?: (index: number) => React.HTMLAttributes<HTMLDivElement>;
+  thumbProps: React.HTMLAttributes<HTMLDivElement>;
 };
 
 /**
@@ -116,7 +116,7 @@ export const Thumb = (props: ThumbProps) => {
   const [isHovered, setIsHovered] = React.useState(false);
 
   const leftPercent = (100.0 * (value - sliderMin)) / (sliderMax - sliderMin);
-  const { style, className, ...rest } = thumbProps?.(index) || {};
+  const { style, className, ...rest } = thumbProps;
 
   return (
     <Tooltip

--- a/src/core/Slider/Track.tsx
+++ b/src/core/Slider/Track.tsx
@@ -45,12 +45,10 @@ export const Track = (props: TrackProps) => {
   const [currentValues, setCurrentValues] = React.useState(
     [...values].sort((a, b) => a - b),
   );
-  const segmentKeyRef = React.useRef(0);
 
   React.useEffect(() => {
     const newValues = [...values];
     newValues.sort((a, b) => a - b);
-    segmentKeyRef.current = segmentKeyRef.current++;
     setCurrentValues(newValues);
   }, [values]);
 
@@ -69,7 +67,7 @@ export const Track = (props: TrackProps) => {
             (100.0 * (segment.right - sliderMin)) / (sliderMax - sliderMin);
           rightPercent = 100.0 - rightPercent;
           return (
-            <React.Fragment key={`${segmentKeyRef.current}-${index}`}>
+            <React.Fragment key={index}>
               {shouldDisplaySegment(index, trackDisplayMode) ? (
                 <div
                   className='iui-slider-track'

--- a/stories/core/Slider.stories.tsx
+++ b/stories/core/Slider.stories.tsx
@@ -182,24 +182,3 @@ DecimalIncrement.args = {
   step: 2.5,
   values: [25],
 };
-
-export const ProcessChange: Story<Partial<SliderProps>> = (args) => {
-  const [sliderValues, setSliderValues] = React.useState([20, 40]);
-
-  return (
-    <Slider
-      {...args}
-      values={sliderValues}
-      onChange={(values) => setSliderValues([...values])}
-    />
-  );
-};
-
-ProcessChange.args = {
-  min: 0,
-  max: 60,
-  tickLabels: ['0', '20', '40', '60'],
-  tooltipProps: (index, val) => {
-    return { placement: 'right', content: `\$${val}.00` };
-  },
-};

--- a/stories/core/Slider.stories.tsx
+++ b/stories/core/Slider.stories.tsx
@@ -182,3 +182,24 @@ DecimalIncrement.args = {
   step: 2.5,
   values: [25],
 };
+
+export const ProcessChange: Story<Partial<SliderProps>> = (args) => {
+  const [sliderValues, setSliderValues] = React.useState([20, 40]);
+
+  return (
+    <Slider
+      {...args}
+      values={sliderValues}
+      onChange={(values) => setSliderValues([...values])}
+    />
+  );
+};
+
+ProcessChange.args = {
+  min: 0,
+  max: 60,
+  tickLabels: ['0', '20', '40', '60'],
+  tooltipProps: (index, val) => {
+    return { placement: 'right', content: `\$${val}.00` };
+  },
+};

--- a/stories/core/Slider.stories.tsx
+++ b/stories/core/Slider.stories.tsx
@@ -47,9 +47,16 @@ export const MultiThumbsAllowCrossing: Story<SliderProps> = (args) => {
 
 MultiThumbsAllowCrossing.args = {
   thumbProps: (index: number) => {
+    const eventsIds = [
+      'building-south',
+      'building-north',
+      'building-west',
+      'building-east',
+    ];
     const color = 0 == index % 2 ? 'blue' : 'red';
     return {
       style: { backgroundColor: color },
+      id: `${eventsIds[index]}`,
     };
   },
   values: [20, 40, 60, 80],


### PR DESCRIPTION
If user used keyboard to change thumb value and there was an onChange listener which was creating a new `values` array, then the thumb would lose focus as it was re-rendered in its new position.

This fixes it by changing the Thumb key to user-provided `id` (with `index` as fallback) instead of maintaining an internal ref count.

This also fixes the issue in the unit tests where it was required to keep looking up the Thumb element because a new unique key was generated anytime the values array was updated.

Closes #233

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [ ] Add an entry to the changelog for any new components and changes
- [x] Add screenshots of the key elements of the component
- [x] Add any additional comments describing the features you've implemented