### PR TITLE
fix(VerticalTabs): orientation should not be required

### DIFF
--- a/src/core/Tabs/Tabs.test.tsx
+++ b/src/core/Tabs/Tabs.test.tsx
@@ -5,7 +5,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Tab } from './Tab';
-import { Tabs, TabsProps } from './Tabs';
+import { Tabs, VerticalTabs, TabsProps } from './Tabs';
 
 const renderComponent = (
   initialProps?: Partial<TabsProps>,
@@ -54,13 +54,24 @@ it('should render pill tabs', () => {
 });
 
 it('should render vertical tabs', () => {
-  const { container } = renderComponent({ orientation: 'vertical' });
+  const { container, queryByText } = render(
+    <VerticalTabs
+      labels={[
+        <Tab key={1} label='Label 1' />,
+        <Tab key={2} label='Label 2' />,
+        <Tab key={3} label='Label 3' />,
+      ]}
+    >
+      Test content
+    </VerticalTabs>,
+  );
 
   expect(
     container.querySelector('.iui-tabs-wrapper.iui-vertical'),
   ).toBeTruthy();
   expect(container.querySelector('.iui-tabs')).toBeTruthy();
   expect(container.querySelector('.iui-tab')).toBeTruthy();
+  expect(queryByText('Test content')).toHaveClass('iui-tabs-content');
 });
 
 it('should render green tabs', () => {

--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -60,11 +60,8 @@ export type TabsProps = {
   children?: React.ReactNode;
 };
 
-export type HorizontalTabsProps = Omit<TabsProps, 'orientation'> & {
-  orientation: 'horizontal';
-};
+export type HorizontalTabsProps = Omit<TabsProps, 'orientation'>;
 export type VerticalTabsProps = Omit<TabsProps, 'orientation' | 'type'> & {
-  orientation: 'vertical';
   type: 'default' | 'borderless';
 };
 
@@ -311,9 +308,31 @@ export const Tabs = (props: TabsProps) => {
   );
 };
 
+/**
+ * Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
+ * @example
+ * const tabs = [
+ *   <Tab label='Label 1' sublabel='First tab' />,
+ *   <Tab label='Label 2' sublabel='Active tab' />,
+ * ];
+ * <HorizontalTabs labels={tabs} activeIndex={1} />
+ */
 export const HorizontalTabs = (props: HorizontalTabsProps) => (
-  <Tabs {...props} />
+  <Tabs orientation='horizontal' {...props} />
 );
-export const VerticalTabs = (props: VerticalTabsProps) => <Tabs {...props} />;
+
+/**
+ * Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
+ * @example
+ * const tabs = [
+ *   <Tab label='Label 1' sublabel='First tab' />,
+ *   <Tab label='Label 2' sublabel='Active tab' />,
+ *   <Tab label='Label 3' icon={<SvgPlaceholder />} />,
+ * ];
+ * <VerticalTabs labels={tabs} activeIndex={1} />
+ */
+export const VerticalTabs = (props: VerticalTabsProps) => (
+  <Tabs orientation='vertical' {...props} />
+);
 
 export default Tabs;

--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -62,7 +62,7 @@ export type TabsProps = {
 
 export type HorizontalTabsProps = Omit<TabsProps, 'orientation'>;
 export type VerticalTabsProps = Omit<TabsProps, 'orientation' | 'type'> & {
-  type: 'default' | 'borderless';
+  type?: 'default' | 'borderless';
 };
 
 /**

--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -314,8 +314,9 @@ export const Tabs = (props: TabsProps) => {
  * const tabs = [
  *   <Tab label='Label 1' sublabel='First tab' />,
  *   <Tab label='Label 2' sublabel='Active tab' />,
+ *   <Tab label='Label 3' sublabel='Disabled tab' disabled icon={<SvgPlaceholder />} />,
  * ];
- * <HorizontalTabs labels={tabs} activeIndex={1} />
+ * <HorizontalTabs labels={tabs} activeIndex={1}>Tabpanel content</HorizontalTabs>
  */
 export const HorizontalTabs = (props: HorizontalTabsProps) => (
   <Tabs orientation='horizontal' {...props} />
@@ -327,9 +328,9 @@ export const HorizontalTabs = (props: HorizontalTabsProps) => (
  * const tabs = [
  *   <Tab label='Label 1' sublabel='First tab' />,
  *   <Tab label='Label 2' sublabel='Active tab' />,
- *   <Tab label='Label 3' icon={<SvgPlaceholder />} />,
+ *   <Tab label='Label 3'  sublabel='Disabled tab' disabled icon={<SvgPlaceholder />} />,
  * ];
- * <VerticalTabs labels={tabs} activeIndex={1} />
+ * <VerticalTabs labels={tabs} activeIndex={1}>Tabpanel content</VerticalTabs>
  */
 export const VerticalTabs = (props: VerticalTabsProps) => (
   <Tabs orientation='vertical' {...props} />

--- a/stories/core/Tabs.stories.tsx
+++ b/stories/core/Tabs.stories.tsx
@@ -26,7 +26,7 @@ export default {
   argTypes: {
     children: { control: { disable: true } },
     style: { control: { disable: true } },
-    orientation: { control: { disable: true } },
+    orientation: { table: { disable: true } },
   },
 } as Meta<TabsProps>;
 
@@ -120,6 +120,6 @@ Vertical.args = {
         startIcon={<SvgStar />}
       />
     )),
-  orientation: 'vertical',
   type: 'borderless',
 };
+Vertical.argTypes = { type: { options: ['default', 'borderless'] } };


### PR DESCRIPTION
Fixed `VerticalTabs` props and component to be rendered correctly. Updated test and story.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] Add component features demo in Storybook (different stories)
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
