### PR TITLE
ci: Update `actions/setup-node` to use built-in caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node 12.X
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 
@@ -43,15 +38,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node 12.X
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 
@@ -74,15 +64,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node 12.X
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
Same as https://github.com/iTwin/iTwinUI/pull/249