### PR TITLE
ci: Fix typo in publish-storybook.yml

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish-storybook:
-    if: "${{ github.event.name === 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'autorelease: tagged') }}"
+    if: "${{ github.event.name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'autorelease: tagged') }}"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Changed `===` to `==`

Source: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators