### PR TITLE
fix: Allow overriding status icon in all input groups

### DIFF
--- a/src/core/InputGroup/InputGroup.tsx
+++ b/src/core/InputGroup/InputGroup.tsx
@@ -77,7 +77,8 @@ export const InputGroup = (props: InputGroupProps) => {
     ...rest
   } = props;
   useTheme();
-  const icon = status ? StatusIconMap[status]() : svgIcon;
+
+  const icon = svgIcon ?? (status && StatusIconMap[status]());
 
   return (
     <div

--- a/src/core/LabeledInput/LabeledInput.tsx
+++ b/src/core/LabeledInput/LabeledInput.tsx
@@ -70,7 +70,7 @@ export const LabeledInput = React.forwardRef<
 
   useTheme();
 
-  const icon = status ? StatusIconMap[status]() : svgIcon;
+  const icon = svgIcon ?? (status && StatusIconMap[status]());
 
   return (
     <label

--- a/src/core/LabeledSelect/LabeledSelect.tsx
+++ b/src/core/LabeledSelect/LabeledSelect.tsx
@@ -102,7 +102,7 @@ export const LabeledSelect = <T,>(
 
   useTheme();
 
-  const icon = status ? StatusIconMap[status]() : svgIcon;
+  const icon = svgIcon ?? (status && StatusIconMap[status]());
 
   return (
     <div

--- a/src/core/LabeledTextarea/LabeledTextarea.tsx
+++ b/src/core/LabeledTextarea/LabeledTextarea.tsx
@@ -84,7 +84,7 @@ export const LabeledTextarea = React.forwardRef<
 
   useTheme();
 
-  const icon = status ? StatusIconMap[status]() : svgIcon;
+  const icon = svgIcon ?? (status && StatusIconMap[status]());
 
   return (
     <label

--- a/stories/core/InputGroup.stories.tsx
+++ b/stories/core/InputGroup.stories.tsx
@@ -16,11 +16,15 @@ import { InputGroupProps } from '../../src/core/InputGroup/InputGroup';
 export default {
   title: 'Input/InputGroup',
   component: InputGroup,
+  args: {
+    displayStyle: 'default',
+  },
   argTypes: {
     className: { control: { disable: true } },
     style: { control: { disable: true } },
     id: { control: { disable: true } },
     svgIcon: { control: { disable: true } },
+    children: { control: { disable: true } },
   },
 } as Meta<InputGroupProps>;
 

--- a/stories/core/LabeledInput.stories.tsx
+++ b/stories/core/LabeledInput.stories.tsx
@@ -15,12 +15,13 @@ export default {
     inputClassName: { control: { disable: true } },
     inputStyle: { control: { disable: true } },
     svgIcon: { control: { disable: true } },
-    disabled: { type: 'boolean' },
     required: { type: 'boolean' },
   },
   args: {
     label: 'This is a label',
     placeholder: 'Enter text here...',
+    displayStyle: 'default',
+    disabled: false,
   },
 } as Meta<LabeledInputProps>;
 

--- a/stories/core/LabeledSelect.stories.tsx
+++ b/stories/core/LabeledSelect.stories.tsx
@@ -24,6 +24,7 @@ export default {
     label: 'This is a label',
     message: 'This is a message',
     placeholder: 'Placeholder text',
+    displayStyle: 'default',
     options: [
       { value: 1, label: 'Item #1' },
       { value: 2, label: 'Item #2' },
@@ -35,6 +36,9 @@ export default {
     className: { control: { disable: true } },
     selectStyle: { control: { disable: true } },
     selectClassName: { control: { disable: true } },
+    menuStyle: { control: { disable: true } },
+    menuClassName: { control: { disable: true } },
+    svgIcon: { control: { disable: true } },
   },
 } as Meta<LabeledSelectProps<unknown>>;
 

--- a/stories/core/LabeledTextarea.stories.tsx
+++ b/stories/core/LabeledTextarea.stories.tsx
@@ -11,10 +11,16 @@ import { LabeledTextareaProps } from '../../src/core/LabeledTextarea/LabeledText
 export default {
   title: 'Input/LabeledTextarea',
   component: LabeledTextarea,
+  argTypes: {
+    textareaClassName: { control: { disable: true } },
+    textareaStyle: { control: { disable: true } },
+    svgIcon: { control: { disable: true } },
+  },
   args: {
     placeholder: 'This is a textarea',
     label: 'Textarea Label',
     message: 'Display Message',
+    displayStyle: 'default',
     disabled: false,
   },
 } as Meta<LabeledTextareaProps>;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9084735/130825666-88a86945-b31e-4b9a-bca5-7a7a6d7cc74c.png)

After:
![image](https://user-images.githubusercontent.com/9084735/130825700-70603c43-4b05-4677-8320-b6e769a234c5.png)

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] Add screenshots of the key elements of the component
