### PR TITLE
chore(deps): Add mkdirp as a direct dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jest-cli": "^27.0.6",
     "jest-junit": "^12.0.0",
     "markdown-to-jsx": "6.11.4",
+    "mkdirp": "^1.0.4",
     "prettier": "^2.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Added `mkdirp` as direct dev dependency in package.json. Nothing changed in lockfile because it's already there:
https://github.com/iTwin/iTwinUI-react/blob/3285db20efd9bda9d7b86ff3dbaea15759bc65f6/yarn.lock#L10363-L10364

We are using it in our `yarn build` command, so we shouldn't rely on a transitive dependency.
