### PR TITLE
fix(Tooltip): Fixed `Tooltip` content clipping when it is next to the viewport edge

### DIFF
--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -69,6 +69,7 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     },
     role: undefined,
     offset: [0, 0],
+    maxWidth: 'none',
     ...props,
     plugins: [
       lazyLoad,

--- a/src/core/utils/Popover.tsx
+++ b/src/core/utils/Popover.tsx
@@ -69,7 +69,7 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     },
     role: undefined,
     offset: [0, 0],
-    maxWidth: 'none',
+    maxWidth: '',
     ...props,
     plugins: [
       lazyLoad,


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #313 <!-- Add issue number -->

`tippy.js` by default has `max-width: 350px` on its container that causes position miscalculation. 
![image](https://user-images.githubusercontent.com/36186912/132637210-739a7016-4c65-4822-9392-13dd62678a3e.png)

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
