### PR TITLE
fix(ComboBox): `onChange` no longer gets called on mount

### DIFF
--- a/src/core/ComboBox/ComboBox.tsx
+++ b/src/core/ComboBox/ComboBox.tsx
@@ -83,7 +83,10 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
 
   // Generate a stateful random id if not specified
   const [id] = React.useState(
-    () => props.id ?? `${inputProps?.id}-cb` ?? `iui-cb-${getRandomValue(10)}`,
+    () =>
+      props.id ??
+      (inputProps?.id && `${inputProps.id}-cb`) ??
+      `iui-cb-${getRandomValue(10)}`,
   );
 
   useTheme();
@@ -108,6 +111,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
           role='option'
           onClick={(value: T) => {
             setSelectedValue(value);
+            onChange?.(value);
             setIsOpen(false);
           }}
           {...rest}
@@ -115,7 +119,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
           {label}
         </MenuItem>
       )),
-    [options, getOptionId],
+    [options, getOptionId, onChange],
   );
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -152,15 +156,14 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
     [inputProps],
   );
 
-  // Fire onChange callback and update inputValue every time selected value changes
+  // update inputValue every time selected value changes
   React.useEffect(() => {
     if (selectedValue != undefined) {
-      onChange?.(selectedValue);
       setInputValue(
         options.find(({ value }) => value === selectedValue)?.label ?? '',
       );
     }
-  }, [selectedValue, onChange, options]);
+  }, [selectedValue, options]);
 
   // Filter options and update focus when input value changes
   React.useEffect(() => {
@@ -237,6 +240,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
         case 'Enter':
           if (isOpen) {
             setSelectedValue(options[focusedIndex].value);
+            onChange?.(options[focusedIndex].value);
           }
           setIsOpen((open) => !open);
           event.preventDefault();
@@ -257,7 +261,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
           break;
       }
     },
-    [focusedIndex, isOpen, options, getOptionId],
+    [focusedIndex, isOpen, options, getOptionId, onChange],
   );
 
   const menuItems = React.useMemo(() => {
@@ -292,21 +296,27 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
     <InputContainer
       className={className}
       isIconInline={true}
-      icon={
-        <span
-          ref={toggleButtonRef}
-          className={cx('iui-actionable', { 'iui-open': isOpen })}
-          onClick={() => {
-            if (isOpen) {
-              setIsOpen(false);
-            } else {
-              inputRef.current?.focus();
-            }
-          }}
-        >
-          <SvgCaretDownSmall aria-hidden />
-        </span>
-      }
+      icon={React.useMemo(
+        () => (
+          <span
+            ref={toggleButtonRef}
+            className={cx({
+              'iui-actionable': !inputProps?.disabled,
+              'iui-open': isOpen,
+            })}
+            onClick={() => {
+              if (isOpen) {
+                setIsOpen(false);
+              } else {
+                inputRef.current?.focus();
+              }
+            }}
+          >
+            <SvgCaretDownSmall aria-hidden />
+          </span>
+        ),
+        [inputProps?.disabled, isOpen],
+      )}
       {...rest}
       id={id}
     >

--- a/stories/core/ComboBox.stories.tsx
+++ b/stories/core/ComboBox.stories.tsx
@@ -322,7 +322,10 @@ export const Controlled: Story<Partial<ComboBoxProps<string>>> = (args) => {
       options={options}
       inputProps={{ placeholder: 'Select a country' }}
       value={countryValue}
-      onChange={(value: string) => setCountryValue(value)}
+      onChange={(value: string) => {
+        action(value)();
+        setCountryValue(value);
+      }}
       {...args}
     />
   );


### PR DESCRIPTION
Moved `onChange` logic out of useEffect so that it's not called on first mount. Closes #368 

I could have [skipped the hook on first mount](https://twitter.com/kentcdodds/status/1111024766700249089), but I chose to duplicate the onChange call into event listeners for click and keydown. This may prevent unexpected bugs caused by users not memoizing the props.

Other fixes:
- id generation will now respect the absence of `inputProps`.
- dropdown arrow will no longer be actionable when `inputProps.disabled` is set.

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
