### PR TITLE
feat(LabeledInput): Set inline icon padding dynamically

### DIFF
--- a/src/core/utils/components/InputContainer.tsx
+++ b/src/core/utils/components/InputContainer.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { useMergedRefs } from '../hooks';
+import { getWindow } from '../functions';
 
 export type InputContainerProps<T extends React.ElementType = 'div'> = {
   as?: T;
@@ -47,8 +48,16 @@ export const InputContainer = React.forwardRef(
     const updateInlinePadding = React.useCallback(
       (el: HTMLElement) => {
         if (el && icon && isIconInline) {
-          const iconWidth = el.querySelector('.iui-input-icon')?.clientWidth;
-          setInlinePadding((iconWidth ?? 0) + 12);
+          const iconEl = el.querySelector('.iui-input-icon') as HTMLElement;
+          const iconStyles = getWindow()?.getComputedStyle(iconEl);
+          if (!iconEl || !iconStyles) {
+            return;
+          }
+          const iconWidth = parseInt(iconStyles.width, 10);
+          const iconMargin =
+            parseInt(iconStyles.marginInlineStart) +
+            parseInt(iconStyles.marginInlineEnd);
+          setInlinePadding(iconWidth + iconMargin + 12);
         }
       },
       [icon, isIconInline],


### PR DESCRIPTION
Sets inline css variable `--inline-icon-width` equal to the `icon`'s width + 12px padding. This adds the flexibility of putting more content than just an IconButton as an inline icon.

Uses https://github.com/iTwin/iTwinUI/pull/362

Before:
![image](https://user-images.githubusercontent.com/9084735/138950746-d000d56f-198b-4cb4-a219-992e096faf64.png)
![image](https://user-images.githubusercontent.com/9084735/138950730-9c82e586-e81d-459b-ad4b-d6dc71c6c056.png)

After:
![image](https://user-images.githubusercontent.com/9084735/138950817-a468472a-cf0d-4de8-a5e1-29e236d9464b.png)
![image](https://user-images.githubusercontent.com/9084735/138950827-00976dd0-6367-4f5d-ad4b-59c540714fb1.png)

Closes # <!-- Add issue number -->

### Review notes:

[Hide whitespace to see what's actually changed](https://github.com/iTwin/iTwinUI-react/pull/403/files?w=1)

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
