### PR TITLE
fix(Select): Set max-width to 2x min-width

### DIFF
--- a/src/core/Select/Select.tsx
+++ b/src/core/Select/Select.tsx
@@ -286,6 +286,7 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
         className={cx('iui-scroll', menuClassName)}
         style={{
           minWidth,
+          maxWidth: `min(${minWidth * 2}px, 90vw)`,
           maxHeight: `300px`,
           ...menuStyle,
         }}


### PR DESCRIPTION
Used same approach as [ComboBox](https://github.com/iTwin/iTwinUI-react/blob/main/src/core/ComboBox/ComboBox.tsx#L348). Replaces the document.offsetWidth logic in #330. Closes #326