### PR TITLE
fix(Tabs): Use scroll position to place stripe

### DIFF
--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -134,8 +134,8 @@ export const Tabs = (props: TabsProps) => {
 
   const [stripeStyle, setStripeStyle] = React.useState<React.CSSProperties>({});
   React.useLayoutEffect(() => {
-    if (type !== 'default') {
-      const activeTab = tablistRef.current?.children[
+    if (tablistRef.current != undefined && type !== 'default') {
+      const activeTab = tablistRef.current.children[
         currentActiveIndex
       ] as HTMLElement;
       const activeTabRect = activeTab?.getBoundingClientRect();
@@ -145,12 +145,12 @@ export const Tabs = (props: TabsProps) => {
         height: orientation === 'vertical' ? activeTabRect?.height : undefined,
         left:
           orientation === 'horizontal'
-            ? activeTab?.offsetLeft
+            ? activeTab.offsetLeft - tablistRef.current.scrollLeft
             : activeTabRect?.width - 2,
         top:
           orientation === 'horizontal'
             ? activeTabRect?.height - 2
-            : activeTab?.offsetTop,
+            : activeTab.offsetTop - tablistRef.current.scrollTop,
       });
     }
   }, [currentActiveIndex, type, orientation, tabsWidth]);


### PR DESCRIPTION
Subtracting scrollLeft/scrollTop gives the right value when the tabs are not in their original scroll position.

Before:
![image](https://user-images.githubusercontent.com/9084735/140766832-92485d14-17f3-4285-8468-9e3ee5edc73f.png)

After:
![image](https://user-images.githubusercontent.com/9084735/140766844-1978238c-831e-49de-b219-a96ebae396c3.png)

Closes # <!-- Add issue number -->

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
