### PR TITLE
chore(deps): Bump itwinui-css to 0.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "^0.38.0",
+    "@itwin/itwinui-css": "^0.39.0",
     "@itwin/itwinui-icons-react": "^1.1.1",
     "@itwin/itwinui-illustrations-react": "^1.0.1",
     "@tippyjs/react": "^4.2.5",

--- a/src/core/Tabs/Tabs.test.tsx
+++ b/src/core/Tabs/Tabs.test.tsx
@@ -32,18 +32,27 @@ it('should render tabs', () => {
 
   const tabContainer = container.querySelector('.iui-tabs') as HTMLElement;
   expect(tabContainer).toBeTruthy();
-  expect(tabContainer.className).toEqual('iui-tabs iui-default');
+  expect(tabContainer).toHaveClass('iui-default');
   expect(tabContainer.querySelectorAll('.iui-tab').length).toBe(3);
   screen.getByText('Test content');
 });
 
-it('should render borderless tabs', () => {
-  const { container } = renderComponent({ type: 'borderless' });
+it.each(['animated', 'not-animated'] as const)(
+  'should render borderless tabs (%s)',
+  (animated) => {
+    window.CSS = {
+      supports: () => !animated.includes('not'),
+      escape: (i) => i,
+    };
 
-  const tabContainer = container.querySelector('.iui-tabs') as HTMLElement;
-  expect(tabContainer).toBeTruthy();
-  expect(tabContainer.className).toContain('iui-tabs iui-borderless');
-});
+    const { container } = renderComponent({ type: 'borderless' });
+
+    const tabContainer = container.querySelector('.iui-tabs') as HTMLElement;
+    expect(tabContainer).toBeTruthy();
+    expect(tabContainer).toHaveClass('iui-borderless');
+    expect(tabContainer).toHaveClass(`iui-${animated}`);
+  },
+);
 
 it('should render pill tabs', () => {
   const { container } = renderComponent({ type: 'pill' });

--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -9,6 +9,7 @@ import {
   useResizeObserver,
   useMergedRefs,
   getBoundedValue,
+  getWindow,
 } from '../utils';
 import '@itwin/itwinui-css/css/tabs.css';
 import { Tab } from './Tab';
@@ -132,25 +133,24 @@ export const Tabs = (props: TabsProps) => {
     }
   }, [activeIndex, currentActiveIndex, labels.length]);
 
-  const [stripeStyle, setStripeStyle] = React.useState<React.CSSProperties>({});
+  // CSS custom properties to place the active stripe
+  const [stripeProperties, setStripeProperties] = React.useState({});
   React.useLayoutEffect(() => {
-    if (type !== 'default') {
-      const activeTab = tablistRef.current?.children[
+    if (type !== 'default' && tablistRef.current != undefined) {
+      const activeTab = tablistRef.current.children[
         currentActiveIndex
       ] as HTMLElement;
-      const activeTabRect = activeTab?.getBoundingClientRect();
+      const activeTabRect = activeTab.getBoundingClientRect();
 
-      setStripeStyle({
-        width: orientation === 'horizontal' ? activeTabRect?.width : undefined,
-        height: orientation === 'vertical' ? activeTabRect?.height : undefined,
-        left:
-          orientation === 'horizontal'
-            ? activeTab?.offsetLeft
-            : activeTabRect?.width - 2,
-        top:
-          orientation === 'horizontal'
-            ? activeTabRect?.height - 2
-            : activeTab?.offsetTop,
+      setStripeProperties({
+        ...(orientation === 'horizontal' && {
+          '--stripe-width': `${activeTabRect.width}px`,
+          '--stripe-left': `${activeTab.offsetLeft}px`,
+        }),
+        ...(orientation === 'vertical' && {
+          '--stripe-height': `${activeTabRect.height}px`,
+          '--stripe-top': `${activeTab.offsetTop}px`,
+        }),
       });
     }
   }, [currentActiveIndex, type, orientation, tabsWidth]);
@@ -243,15 +243,21 @@ export const Tabs = (props: TabsProps) => {
     }
   };
 
+  const isIE = !getWindow()?.CSS?.supports('--stripe-width', '100px');
+
   return (
-    <div className={cx('iui-tabs-wrapper', `iui-${orientation}`)}>
+    <div
+      className={cx('iui-tabs-wrapper', `iui-${orientation}`)}
+      style={stripeProperties}
+    >
       <ul
         className={cx(
           'iui-tabs',
           `iui-${type}`,
           {
             'iui-green': color === 'green',
-            'iui-animated': type !== 'default',
+            'iui-animated': type !== 'default' && !isIE,
+            'iui-not-animated': isIE,
             'iui-large': hasSublabel,
           },
           tabsClassName,
@@ -295,9 +301,6 @@ export const Tabs = (props: TabsProps) => {
           );
         })}
       </ul>
-      {type !== 'default' && (
-        <div className='iui-tab-stripe' style={stripeStyle} />
-      )}
       {children && (
         <div
           className={cx('iui-tabs-content', contentClassName)}

--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -243,7 +243,7 @@ export const Tabs = (props: TabsProps) => {
     }
   };
 
-  const isIE = !getWindow()?.CSS?.supports('--stripe-width', '100px');
+  const isIE = !getWindow()?.CSS?.supports?.('--stripe-width', '100px');
 
   return (
     <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,10 +2361,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@^0.38.0":
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.38.0.tgz#97da48ba1b33baad2bafcb719000fb7a747c5b21"
-  integrity sha512-IRNqT9APOYQCPiUFbxR2SVufW9m/2H+p/03/3EamYqLTlR2BgkbmCEEdb1utmjRgkMbIj94NGxbsrgFXMx8d/w==
+"@itwin/itwinui-css@^0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.39.0.tgz#f1de3911d25e8844ddcb7279560ade0bb2597c7a"
+  integrity sha512-M0DVbDV3X3QH3ikhyD9G6G6RbVfHTDqLiHnvbOxmeAB4UHrPvv+GvjtHkYh3i0BXXenpMjFib3j6cFr/8EksLg==
 
 "@itwin/itwinui-icons-react@^1.1.1":
   version "1.1.3"


### PR DESCRIPTION
Updated to iTwinUI-css 0.39.0. Made required changes in Tabs (switching from `iui-tab-stripe` div to CSS variables).

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
