### PR TITLE
chore(Tabs): Move responsive width logic into reusable hook

### DIFF
--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -6,10 +6,10 @@ import cx from 'classnames';
 import React from 'react';
 import {
   useTheme,
-  useResizeObserver,
   useMergedRefs,
   getBoundedValue,
   getWindow,
+  useContainerWidth,
 } from '../utils';
 import '@itwin/itwinui-css/css/tabs.css';
 import { Tab } from './Tab';
@@ -110,16 +110,7 @@ export const Tabs = (props: TabsProps) => {
   useTheme();
 
   const tablistRef = React.useRef<HTMLUListElement>(null);
-
-  const [tabsWidth, setTabsWidth] = React.useState(
-    () => tablistRef.current?.getBoundingClientRect().width,
-  );
-  const updateTabsWidth = React.useCallback(
-    ({ width }) => setTabsWidth(width),
-    [],
-  );
-
-  const [tablistSizeRef] = useResizeObserver(updateTabsWidth);
+  const [tablistSizeRef, tabsWidth] = useContainerWidth(type !== 'default');
   const refs = useMergedRefs(tablistRef, tablistSizeRef);
 
   const [currentActiveIndex, setCurrentActiveIndex] = React.useState(() =>

--- a/src/core/utils/hooks/index.ts
+++ b/src/core/utils/hooks/index.ts
@@ -6,5 +6,6 @@ export * from './useEventListener';
 export * from './useMergedRefs';
 export * from './useOverflow';
 export * from './useResizeObserver';
+export * from './useContainerWidth';
 export * from './useTheme';
 export * from './useIntersection';

--- a/src/core/utils/hooks/useContainerWidth.test.tsx
+++ b/src/core/utils/hooks/useContainerWidth.test.tsx
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+// import React from 'react';
+import { useContainerWidth } from './useContainerWidth';
+import * as UseResizeObserver from './useResizeObserver';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('should set initial size', () => {
+  const { result } = renderHook(() => useContainerWidth());
+  const element = document.createElement('div');
+  Object.defineProperties(element, {
+    getBoundingClientRect: { value: () => ({ width: 100 }) },
+  });
+  act(() => {
+    result.current[0](element);
+  });
+
+  expect(result.current[1]).toEqual(100);
+});
+
+it('should update value when resized', () => {
+  let triggerResize: (size: DOMRectReadOnly) => void = jest.fn();
+  jest
+    .spyOn(UseResizeObserver, 'useResizeObserver')
+    .mockImplementation((onResize) => {
+      triggerResize = onResize;
+      return [
+        jest.fn(),
+        ({ disconnect: jest.fn() } as unknown) as ResizeObserver,
+      ];
+    });
+  const { result } = renderHook(() => useContainerWidth());
+  const element = document.createElement('div');
+  Object.defineProperties(element, {
+    getBoundingClientRect: { value: () => ({ width: 100 }) },
+  });
+  act(() => {
+    result.current[0](element);
+  });
+
+  expect(result.current[1]).toEqual(100);
+
+  act(() => triggerResize({ width: 125 } as DOMRect));
+  expect(result.current[1]).toEqual(125);
+
+  act(() => triggerResize({ width: 150 } as DOMRect));
+  expect(result.current[1]).toEqual(150);
+});
+
+it('should not update value when resized if disabled', () => {
+  let triggerResize: (size: DOMRectReadOnly) => void = jest.fn();
+  const disconnect = jest.fn(() => {
+    triggerResize = jest.fn();
+  });
+  jest
+    .spyOn(UseResizeObserver, 'useResizeObserver')
+    .mockImplementation((onResize) => {
+      triggerResize = onResize;
+      return [jest.fn(), ({ disconnect } as unknown) as ResizeObserver];
+    });
+  const { result, waitFor } = renderHook(() => useContainerWidth(false));
+  const element = document.createElement('div');
+  Object.defineProperties(element, {
+    getBoundingClientRect: { value: () => ({ width: 100 }) },
+  });
+  act(() => {
+    result.current[0](element);
+  });
+
+  expect(result.current[1]).toEqual(100);
+
+  act(() => triggerResize({ width: 125 } as DOMRect));
+  waitFor(() => expect(result.current[1]).toEqual(100));
+  expect(disconnect).toHaveBeenCalled();
+});

--- a/src/core/utils/hooks/useContainerWidth.test.tsx
+++ b/src/core/utils/hooks/useContainerWidth.test.tsx
@@ -68,7 +68,7 @@ it('should not update value when resized if disabled', () => {
       triggerResize = onResize;
       return [jest.fn(), ({ disconnect } as unknown) as ResizeObserver];
     });
-  const { result, waitFor } = renderHook(() => useContainerWidth(false));
+  const { result } = renderHook(() => useContainerWidth(false));
   const element = document.createElement('div');
   Object.defineProperties(element, {
     getBoundingClientRect: { value: () => ({ width: 100 }) },
@@ -80,6 +80,6 @@ it('should not update value when resized if disabled', () => {
   expect(result.current[1]).toEqual(100);
 
   act(() => triggerResize({ width: 125 } as DOMRect));
-  waitFor(() => expect(result.current[1]).toEqual(100));
+  expect(result.current[1]).toEqual(100);
   expect(disconnect).toHaveBeenCalled();
 });

--- a/src/core/utils/hooks/useContainerWidth.test.tsx
+++ b/src/core/utils/hooks/useContainerWidth.test.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-// import React from 'react';
 import { useContainerWidth } from './useContainerWidth';
 import * as UseResizeObserver from './useResizeObserver';
 import { renderHook, act } from '@testing-library/react-hooks';
@@ -15,16 +14,20 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it('should set initial size', () => {
-  const { result } = renderHook(() => useContainerWidth());
+const renderHookComponent = (watchResizes = true) => {
+  const hook = renderHook(() => useContainerWidth(watchResizes));
   const element = document.createElement('div');
   Object.defineProperties(element, {
     getBoundingClientRect: { value: () => ({ width: 100 }) },
   });
   act(() => {
-    result.current[0](element);
+    hook.result.current[0](element);
   });
+  return hook;
+};
 
+it('should set initial size', () => {
+  const { result } = renderHookComponent();
   expect(result.current[1]).toEqual(100);
 });
 
@@ -39,14 +42,7 @@ it('should update value when resized', () => {
         ({ disconnect: jest.fn() } as unknown) as ResizeObserver,
       ];
     });
-  const { result } = renderHook(() => useContainerWidth());
-  const element = document.createElement('div');
-  Object.defineProperties(element, {
-    getBoundingClientRect: { value: () => ({ width: 100 }) },
-  });
-  act(() => {
-    result.current[0](element);
-  });
+  const { result } = renderHookComponent();
 
   expect(result.current[1]).toEqual(100);
 
@@ -68,14 +64,7 @@ it('should not update value when resized if disabled', () => {
       triggerResize = onResize;
       return [jest.fn(), ({ disconnect } as unknown) as ResizeObserver];
     });
-  const { result } = renderHook(() => useContainerWidth(false));
-  const element = document.createElement('div');
-  Object.defineProperties(element, {
-    getBoundingClientRect: { value: () => ({ width: 100 }) },
-  });
-  act(() => {
-    result.current[0](element);
-  });
+  const { result } = renderHookComponent(false);
 
   expect(result.current[1]).toEqual(100);
 

--- a/src/core/utils/hooks/useContainerWidth.tsx
+++ b/src/core/utils/hooks/useContainerWidth.tsx
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from 'react';
+import { useMergedRefs } from './useMergedRefs';
+import { useResizeObserver } from './useResizeObserver';
+
+/**
+ * Hook that returns the width of an element in three stages:
+ *  - initialized with 0
+ *  - immediately set to element's initial width as soon as it's mounted
+ *  - update to new width every time it changes (using `useResizeObserver` hook)
+ *
+ * @private
+ * @param watchResizes If false, ResizeObserver will not be connected and only the initial width will be returned
+ * @returns [ref to attach to the element, stateful width of the element]
+ *
+ * @example
+ * const [ref, width] = useContainerWidth();
+ * ... // do something with width
+ * return <div ref={ref}>...</div>;
+ */
+export const useContainerWidth = <T extends HTMLElement>(
+  watchResizes = true,
+) => {
+  const [contentWidth, setContentWidth] = React.useState(0);
+
+  // callback ref to set initial contentWidth only once
+  const isInitialized = React.useRef(false);
+  const ref = React.useCallback((element: T) => {
+    if (!element) {
+      return;
+    }
+    if (!isInitialized.current) {
+      setContentWidth(element.getBoundingClientRect().width);
+    } else {
+      isInitialized.current = true;
+    }
+  }, []);
+
+  const updateWidth = React.useCallback(
+    ({ width }) => setContentWidth(width),
+    [],
+  );
+
+  const [resizeRef, resizeObserver] = useResizeObserver(updateWidth);
+
+  if (!watchResizes) {
+    resizeObserver?.disconnect();
+  }
+
+  const refs = useMergedRefs(ref, watchResizes ? resizeRef : undefined);
+
+  return [refs, contentWidth] as const;
+};
+
+export default useContainerWidth;

--- a/src/core/utils/hooks/useContainerWidth.tsx
+++ b/src/core/utils/hooks/useContainerWidth.tsx
@@ -26,16 +26,11 @@ export const useContainerWidth = <T extends HTMLElement>(
 ) => {
   const [contentWidth, setContentWidth] = React.useState(0);
 
-  // callback ref to set initial contentWidth only once
-  const isInitialized = React.useRef(false);
   const ref = React.useCallback((element: T) => {
     if (!element) {
       return;
     }
-    if (!isInitialized.current) {
-      setContentWidth(element.getBoundingClientRect().width);
-      isInitialized.current = true;
-    }
+    setContentWidth(element.getBoundingClientRect().width);
   }, []);
 
   const updateWidth = React.useCallback(

--- a/src/core/utils/hooks/useContainerWidth.tsx
+++ b/src/core/utils/hooks/useContainerWidth.tsx
@@ -34,7 +34,6 @@ export const useContainerWidth = <T extends HTMLElement>(
     }
     if (!isInitialized.current) {
       setContentWidth(element.getBoundingClientRect().width);
-    } else {
       isInitialized.current = true;
     }
   }, []);


### PR DESCRIPTION
Added new hook `useContainerWidth` to allow reusing the logic for responsive width from Tabs. This hook will be used in `InformationPanelContent` in my next PR.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
