### PR TITLE
feat(Tabs): Add `wrapperClassName` prop

### DIFF
--- a/src/core/Tabs/Tabs.test.tsx
+++ b/src/core/Tabs/Tabs.test.tsx
@@ -157,12 +157,18 @@ it('should add custom classnames', () => {
   const { container } = renderComponent({
     tabsClassName: 'customTabsClassName',
     contentClassName: 'customContentClassName',
+    wrapperClassName: 'customWrapperClassName',
   });
 
-  const tabsContainer = container.querySelector('ul.customTabsClassName');
-  expect(tabsContainer).toBeTruthy();
-  const content = container.querySelector('div.customContentClassName');
-  expect(content).toBeTruthy();
+  expect(container.querySelector('.iui-tabs-wrapper')).toHaveClass(
+    'customWrapperClassName',
+  );
+  expect(container.querySelector('ul.iui-tabs')).toHaveClass(
+    'customTabsClassName',
+  );
+  expect(container.querySelector('.iui-tabs-content')).toHaveClass(
+    'customContentClassName',
+  );
 });
 
 it.each(['horizontal', 'vertical'] as const)(

--- a/src/core/Tabs/Tabs.tsx
+++ b/src/core/Tabs/Tabs.tsx
@@ -58,6 +58,10 @@ export type TabsProps = {
    */
   contentClassName?: string;
   /**
+   * Custom CSS class name for the tabs wrapper.
+   */
+  wrapperClassName?: string;
+  /**
    * Content inside the tab panel.
    */
   children?: React.ReactNode;
@@ -103,6 +107,7 @@ export const Tabs = (props: TabsProps) => {
     orientation = 'horizontal',
     tabsClassName,
     contentClassName,
+    wrapperClassName,
     children,
     ...rest
   } = props;
@@ -238,7 +243,7 @@ export const Tabs = (props: TabsProps) => {
 
   return (
     <div
-      className={cx('iui-tabs-wrapper', `iui-${orientation}`)}
+      className={cx('iui-tabs-wrapper', `iui-${orientation}`, wrapperClassName)}
       style={stripeProperties}
     >
       <ul


### PR DESCRIPTION
Take two after #420 where I tried adding `className`. This time I'm adding `wrapperClassName` as it's more consistent with the other props, even if we remove it in 2.0.

Closes #450 

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
