### PR TITLE
fix(Table): Prevents from triggering sort when filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^7.0.1",
+    "@testing-library/user-event": "^13.5.0",
     "@types/classnames": "^2.2.7",
     "@types/jest": "^27.0.0",
     "@types/node": "^10.12.2",

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -19,6 +19,7 @@ import { EditableCell } from './cells';
 import { TablePaginator } from './TablePaginator';
 import * as UseOverflow from '../utils/hooks/useOverflow';
 import * as UseResizeObserver from '../utils/hooks/useResizeObserver';
+import userEvent from '@testing-library/user-event';
 
 const intersectionCallbacks = new Map<Element, () => void>();
 jest
@@ -148,7 +149,7 @@ function assertRowsData(rows: NodeListOf<Element>, data = mockedData()) {
     expect(cells[0].textContent).toEqual(name);
     expect(cells[1].textContent).toEqual(description);
     expect(cells[2].textContent).toEqual('View');
-    fireEvent.click(cells[2].firstElementChild as HTMLElement);
+    userEvent.click(cells[2].firstElementChild as HTMLElement);
   }
 }
 
@@ -157,15 +158,15 @@ const setFilter = (container: HTMLElement, value: string) => {
     '.iui-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
-  fireEvent.click(filterIcon);
+  userEvent.click(filterIcon);
 
   const filterInput = document.querySelector(
     '.iui-column-filter input',
   ) as HTMLInputElement;
   expect(filterInput).toBeTruthy();
 
-  fireEvent.change(filterInput, { target: { value } });
-  screen.getByText('Filter').click();
+  userEvent.type(filterInput, value);
+  userEvent.click(screen.getByText('Filter'));
 };
 
 const clearFilter = (container: HTMLElement) => {
@@ -173,7 +174,7 @@ const clearFilter = (container: HTMLElement) => {
     '.iui-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
-  fireEvent.click(filterIcon);
+  userEvent.click(filterIcon);
 
   screen.getByText('Clear').click();
 };
@@ -183,7 +184,7 @@ const expandAll = (container: HTMLElement, oldExpanders: Element[] = []) => {
     container.querySelectorAll('.iui-row-expander'),
   );
   const newExpanders = allExpanders.filter((e) => !oldExpanders.includes(e));
-  newExpanders.forEach((button) => fireEvent.click(button));
+  newExpanders.forEach((button) => userEvent.click(button));
   if (newExpanders.length) {
     expandAll(container, allExpanders);
   }
@@ -294,13 +295,13 @@ it('should handle checkbox clicks', () => {
 
   const checkboxCells = container.querySelectorAll('.iui-slot .iui-checkbox');
   expect(checkboxCells.length).toBe(4);
-  fireEvent.click(checkboxCells[2]);
+  userEvent.click(checkboxCells[2]);
   expect(onSelect).toHaveBeenCalledWith([mockedData()[1]], expect.any(Object));
 
-  fireEvent.click(checkboxCells[0]);
+  userEvent.click(checkboxCells[0]);
   expect(onSelect).toHaveBeenCalledWith(mockedData(), expect.any(Object));
 
-  fireEvent.click(checkboxCells[0]);
+  userEvent.click(checkboxCells[0]);
   expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
 });
 
@@ -317,18 +318,18 @@ it('should handle row clicks', () => {
   const rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(3);
 
-  fireEvent.click(getByText(mockedData()[1].name));
+  userEvent.click(getByText(mockedData()[1].name));
   expect(rows[1].classList).toContain('iui-selected');
   expect(onSelect).toHaveBeenCalledTimes(1);
   expect(onRowClick).toHaveBeenCalledTimes(1);
 
-  fireEvent.click(getByText(mockedData()[2].name));
+  userEvent.click(getByText(mockedData()[2].name));
   expect(rows[1].classList).not.toContain('iui-selected');
   expect(rows[2].classList).toContain('iui-selected');
   expect(onSelect).toHaveBeenCalledTimes(2);
   expect(onRowClick).toHaveBeenCalledTimes(2);
 
-  fireEvent.click(getByText(mockedData()[1].name), { ctrlKey: true });
+  userEvent.click(getByText(mockedData()[1].name), { ctrlKey: true });
   expect(rows[1].classList).toContain('iui-selected');
   expect(rows[2].classList).toContain('iui-selected');
   expect(onSelect).toHaveBeenCalledTimes(3);
@@ -349,7 +350,7 @@ it('should not select when clicked on row but selectRowOnClick flag is false', (
   const rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(3);
 
-  fireEvent.click(getByText(mockedData()[1].name));
+  userEvent.click(getByText(mockedData()[1].name));
   expect(onSelect).not.toHaveBeenCalled();
   expect(onRowClick).toHaveBeenCalled();
 });
@@ -386,7 +387,7 @@ it('should not trigger onSelect when sorting and filtering', () => {
   expect(nameHeader).toBeTruthy();
   expect(nameHeader.classList).not.toContain('iui-sorted');
 
-  fireEvent.mouseDown(nameHeader);
+  userEvent.click(nameHeader);
   expect(onSort).toHaveBeenCalled();
   expect(onSelect).not.toHaveBeenCalled();
 
@@ -450,7 +451,7 @@ it('should sort name column correctly', () => {
   expect(sortIcon).toBeTruthy();
 
   //first click
-  fireEvent.mouseDown(nameHeader);
+  userEvent.click(nameHeader);
   rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(nameHeader.classList).toContain('iui-sorted');
   assertRowsData(rows, sortedByName);
@@ -466,7 +467,7 @@ it('should sort name column correctly', () => {
   );
 
   //second click
-  fireEvent.mouseDown(nameHeader);
+  userEvent.click(nameHeader);
   rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(nameHeader.classList).toContain('iui-sorted');
   assertRowsData(rows, [...sortedByName].reverse());
@@ -482,7 +483,7 @@ it('should sort name column correctly', () => {
   );
 
   //third click resets it
-  fireEvent.mouseDown(nameHeader);
+  userEvent.click(nameHeader);
   rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(nameHeader.classList).not.toContain('iui-sorted');
   assertRowsData(rows, mocked);
@@ -616,7 +617,7 @@ it('should clear filter', () => {
     '.iui-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
-  fireEvent.click(filterIcon);
+  userEvent.click(filterIcon);
 
   const filterInput = document.querySelector(
     '.iui-column-filter input',
@@ -806,6 +807,7 @@ it('should not trigger sorting when filter is clicked', () => {
     columns: mockedColumns,
     onFilter,
     onSort,
+    isSortable: true,
   });
 
   setFilter(container, '2');
@@ -915,7 +917,7 @@ it('should expand correctly', () => {
   ).toEqual(expanderIcon);
 
   act(() => {
-    fireEvent.click(container.querySelectorAll('.iui-button')[0]);
+    userEvent.click(container.querySelectorAll('.iui-button')[0]);
   });
 
   getByText('Expanded component, name: Name1');
@@ -945,16 +947,16 @@ it('should expand correctly with a custom expander cell', async () => {
   expect(queryByText('Expanded component, name: Name3')).toBeNull();
 
   act(() => {
-    fireEvent.click(getByText('Expand Name1'));
-    fireEvent.click(getByText('Expand Name2'));
+    userEvent.click(getByText('Expand Name1'));
+    userEvent.click(getByText('Expand Name2'));
   });
 
   getByText('Expanded component, name: Name1');
   getByText('Expanded component, name: Name2');
 
   act(() => {
-    fireEvent.click(getByText('Expand Name1'));
-    fireEvent.click(getByText('Expand Name3'));
+    userEvent.click(getByText('Expand Name1'));
+    userEvent.click(getByText('Expand Name3'));
   });
   await waitFor(() =>
     expect(queryByText('Expanded component, name: Name1')).toBeNull(),
@@ -989,10 +991,10 @@ it('should disable row and handle expansion accordingly', () => {
   expect(expansionCells[1].disabled).toBe(true);
   expect(expansionCells[2].disabled).toBe(false);
 
-  fireEvent.click(expansionCells[1]);
+  userEvent.click(expansionCells[1]);
   expect(onExpand).not.toHaveBeenCalled();
 
-  fireEvent.click(expansionCells[0]);
+  userEvent.click(expansionCells[0]);
   expect(onExpand).toHaveBeenCalled();
 });
 
@@ -1021,12 +1023,12 @@ it('should disable row and handle selection accordingly', () => {
   expect(checkboxCells[3].classList).not.toContain('iui-disabled');
 
   // Select disabled row
-  fireEvent.click(checkboxCells[2]);
+  userEvent.click(checkboxCells[2]);
   expect(onSelect).not.toHaveBeenCalled();
   expect(onRowClick).not.toHaveBeenCalled();
 
   // Select first row
-  fireEvent.click(checkboxCells[1]);
+  userEvent.click(checkboxCells[1]);
   expect(onSelect).toHaveBeenCalledWith([mockedData()[0]], expect.any(Object));
   const headerCheckbox = checkboxCells[0].querySelector(
     'input',
@@ -1035,7 +1037,7 @@ it('should disable row and handle selection accordingly', () => {
   expect(headerCheckbox.checked).toBe(false);
 
   // Select all
-  fireEvent.click(checkboxCells[0]);
+  userEvent.click(checkboxCells[0]);
   expect(onSelect).toHaveBeenCalledWith(
     [mockedData()[0], mockedData()[2]],
     expect.any(Object),
@@ -1044,7 +1046,7 @@ it('should disable row and handle selection accordingly', () => {
   expect(headerCheckbox.checked).toBe(true);
 
   // Deselect all
-  fireEvent.click(checkboxCells[0]);
+  userEvent.click(checkboxCells[0]);
   expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
   expect(headerCheckbox.indeterminate).toBe(false);
   expect(headerCheckbox.checked).toBe(false);
@@ -1079,7 +1081,7 @@ it('should select and filter rows', () => {
   expect(checkboxCells.length).toBe(4);
 
   // Select first row
-  fireEvent.click(checkboxCells[1]);
+  userEvent.click(checkboxCells[1]);
   expect(onSelect).toHaveBeenCalledWith([mockedData()[0]], expect.any(Object));
   const headerCheckbox = checkboxCells[0].querySelector(
     'input',
@@ -1094,7 +1096,7 @@ it('should select and filter rows', () => {
   expect(checkboxCells.length).toBe(2);
 
   // Select second row
-  fireEvent.click(checkboxCells[1]);
+  userEvent.click(checkboxCells[1]);
   expect(onSelect).toHaveBeenCalledWith(
     [mockedData()[0], mockedData()[1]],
     expect.any(Object),
@@ -1435,7 +1437,7 @@ it('should show indeterminate checkbox when clicking on a row itself after filte
   rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(7);
   // Click row 1
-  fireEvent.click(rows[0]);
+  userEvent.click(rows[0]);
 
   const checkboxes = container.querySelectorAll<HTMLInputElement>(
     '.iui-table-body .iui-checkbox input',
@@ -1504,9 +1506,9 @@ it('should render sub-rows with custom expander', () => {
   let rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(3);
 
-  fireEvent.click(screen.getByText('Expand Row 1'));
-  fireEvent.click(screen.getByText('Expand Row 1.2'));
-  fireEvent.click(screen.getByText('Expand Row 2'));
+  userEvent.click(screen.getByText('Expand Row 1'));
+  userEvent.click(screen.getByText('Expand Row 1.2'));
+  userEvent.click(screen.getByText('Expand Row 2'));
 
   rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(10);
@@ -1620,7 +1622,7 @@ it('should handle unwanted actions on editable cell', () => {
     mockedData()[1],
   );
 
-  fireEvent.click(editableCells[1]);
+  userEvent.click(editableCells[1]);
   expect(onSelect).not.toHaveBeenCalled();
 });
 

--- a/src/core/Table/filters/BaseFilter.tsx
+++ b/src/core/Table/filters/BaseFilter.tsx
@@ -38,7 +38,7 @@ export const BaseFilter = (props: BaseFilterProps) => {
     <div
       className={cx('iui-column-filter', className)}
       style={style}
-      onClick={(e: React.MouseEvent) => {
+      onMouseDown={(e: React.MouseEvent) => {
         e.stopPropagation();
       }}
       id={id}

--- a/src/core/Table/filters/BaseFilter.tsx
+++ b/src/core/Table/filters/BaseFilter.tsx
@@ -38,6 +38,7 @@ export const BaseFilter = (props: BaseFilterProps) => {
     <div
       className={cx('iui-column-filter', className)}
       style={style}
+      // Prevents from triggering sort
       onMouseDown={(e: React.MouseEvent) => {
         e.stopPropagation();
       }}

--- a/src/core/Table/filters/FilterButtonBar.test.tsx
+++ b/src/core/Table/filters/FilterButtonBar.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FilterButtonBar, FilterButtonBarProps } from './FilterButtonBar';
 import { BaseFilter } from './BaseFilter';
+import userEvent from '@testing-library/user-event';
 
 const setFilter = jest.fn();
 const clearFilter = jest.fn();
@@ -80,15 +81,14 @@ it('should call callbacks on clicks', () => {
 it('should consume the click event and stop its propagation', () => {
   const parentClick = jest.fn();
   render(
-    <div onClick={parentClick}>
+    <div onMouseDown={parentClick}>
       <BaseFilter>
         <FilterButtonBar setFilter={setFilter} clearFilter={clearFilter} />
       </BaseFilter>
     </div>,
   );
 
-  screen.getByText('Filter').click();
-
-  screen.getByText('Clear').click();
+  userEvent.click(screen.getByText('Filter'));
+  userEvent.click(screen.getByText('Clear'));
   expect(parentClick).not.toHaveBeenCalled();
 });

--- a/src/core/Table/filters/FilterToggle.tsx
+++ b/src/core/Table/filters/FilterToggle.tsx
@@ -56,10 +56,10 @@ export const FilterToggle = <T extends Record<string, unknown>>(
             styleType='borderless'
             isActive={isVisible || column.filterValue}
             className={cx('iui-filter-button', className)}
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation();
+            onClick={() => {
               setIsVisible((v) => !v);
             }}
+            onMouseDown={(e) => e.stopPropagation()}
             {...rest}
           >
             {column.filterValue ? <SvgFilter /> : <SvgFilterHollow />}

--- a/src/core/Table/filters/FilterToggle.tsx
+++ b/src/core/Table/filters/FilterToggle.tsx
@@ -59,6 +59,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
             onClick={() => {
               setIsVisible((v) => !v);
             }}
+            // Prevents from triggering sort
             onMouseDown={(e) => e.stopPropagation()}
             {...rest}
           >

--- a/src/core/Table/hooks/useResizeColumns.tsx
+++ b/src/core/Table/hooks/useResizeColumns.tsx
@@ -185,11 +185,13 @@ const defaultGetResizerProps = (ownerDocument: Document | undefined) => (
     {
       onMouseDown: (e: React.MouseEvent) => {
         e.persist();
+        // Prevents from triggering sort
         e.stopPropagation();
         onResizeStart(e, header);
       },
       onTouchStart: (e: React.TouchEvent) => {
         e.persist();
+        // Prevents from triggering sort
         e.stopPropagation();
         onResizeStart(e, header);
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3769,6 +3769,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
+"@testing-library/user-event@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@tippyjs/react@^4.2.5":
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.5.tgz#9b5837db93a1cac953962404df906aef1a18e80d"


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #483
I was trying to think of better solution instead of adding `e.stopPropagation()` but every time I would bump into edge case that breaks the fix.
I thought that this should do the trick:
```tsx
<div
  onMouseDown={e => {
    if (e.target === e.currentTarget) {
      onSortClick(e);
    }
  }}
/>  
```
But clicking on sort icon would not sort, also if users have some elements inside header, clicking on them would also not sort.

I am using `userEvent` in `Table` tests because its click simulates real user click: `pointerDown`, `mouseDown`, `focus`, `pointerUp`, `mouseUp`, and `click`.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
