### PR TITLE
fix(Modal): Dont use `stopPropagation` for closing on backdrop click

### DIFF
--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -183,7 +183,11 @@ export const Modal = (props: ModalProps) => {
               style={style}
               role='dialog'
               aria-modal='true'
-              onMouseDown={(event) => event.stopPropagation()}
+              onMouseDown={(event) => {
+                if (closeOnExternalClick) {
+                  event.stopPropagation();
+                }
+              }}
             >
               <div className='iui-title-bar'>
                 <div className='iui-title'>{title}</div>

--- a/src/core/Modal/Modal.tsx
+++ b/src/core/Modal/Modal.tsx
@@ -160,6 +160,9 @@ export const Modal = (props: ModalProps) => {
   const handleMouseDown = (event: React.MouseEvent) => {
     // Prevents React from resetting its properties
     event.persist();
+    if (event.target !== overlayRef.current) {
+      return;
+    }
     if (isDismissible && closeOnExternalClick && onClose) {
       onClose(event);
     }
@@ -183,11 +186,6 @@ export const Modal = (props: ModalProps) => {
               style={style}
               role='dialog'
               aria-modal='true'
-              onMouseDown={(event) => {
-                if (closeOnExternalClick) {
-                  event.stopPropagation();
-                }
-              }}
             >
               <div className='iui-title-bar'>
                 <div className='iui-title'>{title}</div>


### PR DESCRIPTION
### History
For the `closeOnExternalClick` feature, previously we were using `stopPropagation` in the modal dialog mousedown so that the event doesn't reach the backdrop (parent)'s mousedown handler. This allowed us to simply call `onClose` in the backdrop.

### Change
`stopPropagation` causes problems with such as the one reported in #516, so now instead of relying on `stopPropagation`, I'm checking against target to discard modal dialog clicks.

### Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
