### PR TITLE
fix(Button): Fix event typings for inline handlers

### DIFF
--- a/src/core/Buttons/Button/Button.test.tsx
+++ b/src/core/Buttons/Button/Button.test.tsx
@@ -10,7 +10,13 @@ import { Button } from './Button';
 it('renders default button correctly', () => {
   const onClickMock = jest.fn();
   const { container } = render(
-    <Button onClick={onClickMock}>Click me!</Button>,
+    <Button
+      onClick={(e) => {
+        onClickMock(e);
+      }}
+    >
+      Click me!
+    </Button>,
   );
 
   const button = container.querySelector('.iui-button') as HTMLButtonElement;

--- a/src/core/utils/props.ts
+++ b/src/core/utils/props.ts
@@ -61,9 +61,9 @@ export interface PolymorphicForwardRefComponent<
   > {
   <As = T>(
     props: As extends keyof JSX.IntrinsicElements
-      ? Merge<JSX.IntrinsicElements[As], OwnProps & { as?: As }>
+      ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
       : As extends React.ComponentType<infer P>
-      ? Merge<P, OwnProps & { as?: As }>
+      ? Merge<P, OwnProps & { as: As }>
       : never,
   ): React.ReactElement | null;
 }


### PR DESCRIPTION
Making `as` optional in the type narrowing breaks automatic inferring of function props (like event handlers and ref). Modified one of the tests to include an inline handler so that we don't get this bug again.

Before this PR:
![image](https://user-images.githubusercontent.com/9084735/150412134-56b359a9-96f2-418a-a825-0dd62a6cd74b.png)

After this PR:
![image](https://user-images.githubusercontent.com/9084735/150412273-0da7199d-f8e0-451e-a8b8-8ccb411f2d76.png)

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
