### PR TITLE
feat(ButtonGroup): Add new `overflowPlacement` prop

### DIFF
--- a/src/core/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/core/ButtonGroup/ButtonGroup.test.tsx
@@ -35,7 +35,7 @@ it('should render with four buttons', () => {
 
 it.each(['start', 'end'] as const)(
   'should handle overflow when overflowButton is specified (%s)',
-  (overflowPosition) => {
+  (overflowPlacement) => {
     const scrollWidthSpy = jest
       .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
       .mockReturnValueOnce(250)
@@ -59,7 +59,7 @@ it.each(['start', 'end'] as const)(
               <SvgMore />
             </IconButton>
           )}
-          overflowPosition={overflowPosition}
+          overflowPlacement={overflowPlacement}
         >
           {buttons}
         </ButtonGroup>
@@ -71,7 +71,7 @@ it.each(['start', 'end'] as const)(
 
     const buttons = container.querySelectorAll('.iui-button');
     expect(buttons).toHaveLength(2);
-    fireEvent.click(overflowPosition === 'end' ? buttons[1] : buttons[0]);
+    fireEvent.click(overflowPlacement === 'end' ? buttons[1] : buttons[0]);
     expect(mockOnClick).toHaveBeenCalledWith(2);
 
     scrollWidthSpy.mockRestore();

--- a/src/core/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/core/ButtonGroup/ButtonGroup.test.tsx
@@ -33,44 +33,48 @@ it('should render with four buttons', () => {
   expect(container.querySelectorAll('button').length).toBe(4);
 });
 
-it('should handle overflow when overflowButton is specified', () => {
-  const scrollWidthSpy = jest
-    .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
-    .mockReturnValueOnce(250)
-    .mockReturnValue(200);
-  const offsetWidthSpy = jest
-    .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
-    .mockReturnValue(200);
+it.each(['start', 'end'] as const)(
+  'should handle overflow when overflowButton is specified (%s)',
+  (overflowPosition) => {
+    const scrollWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+      .mockReturnValueOnce(250)
+      .mockReturnValue(200);
+    const offsetWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(200);
 
-  const mockOnClick = jest.fn();
+    const mockOnClick = jest.fn();
 
-  const OverflowGroup = () => {
-    const buttons = [...Array(3)].map((_, index) => (
-      <IconButton key={index}>
-        <SvgPlaceholder />
-      </IconButton>
-    ));
-    return (
-      <ButtonGroup
-        overflowButton={(overflowStart) => (
-          <IconButton onClick={() => mockOnClick(overflowStart)}>
-            <SvgMore />
-          </IconButton>
-        )}
-      >
-        {buttons}
-      </ButtonGroup>
-    );
-  };
-  const { container } = render(<OverflowGroup />);
+    const OverflowGroup = () => {
+      const buttons = [...Array(3)].map((_, index) => (
+        <IconButton key={index}>
+          <SvgPlaceholder />
+        </IconButton>
+      ));
+      return (
+        <ButtonGroup
+          overflowButton={(overflowStart) => (
+            <IconButton onClick={() => mockOnClick(overflowStart)}>
+              <SvgMore />
+            </IconButton>
+          )}
+          overflowPosition={overflowPosition}
+        >
+          {buttons}
+        </ButtonGroup>
+      );
+    };
+    const { container } = render(<OverflowGroup />);
 
-  expect(container.querySelector('.iui-button-group')).toBeTruthy();
+    expect(container.querySelector('.iui-button-group')).toBeTruthy();
 
-  const buttons = container.querySelectorAll('.iui-button');
-  expect(buttons).toHaveLength(2);
-  fireEvent.click(buttons[1]);
-  expect(mockOnClick).toHaveBeenCalledWith(2);
+    const buttons = container.querySelectorAll('.iui-button');
+    expect(buttons).toHaveLength(2);
+    fireEvent.click(overflowPosition === 'end' ? buttons[1] : buttons[0]);
+    expect(mockOnClick).toHaveBeenCalledWith(2);
 
-  scrollWidthSpy.mockRestore();
-  offsetWidthSpy.mockRestore();
-});
+    scrollWidthSpy.mockRestore();
+    offsetWidthSpy.mockRestore();
+  },
+);

--- a/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/src/core/ButtonGroup/ButtonGroup.tsx
@@ -20,6 +20,11 @@ export type ButtonGroupProps = {
    * and returns the `ReactNode` to render.
    */
   overflowButton?: (firstOverflowingIndex: number) => React.ReactNode;
+  /**
+   * If `overflowButton` is specified, should it placed at the start or the end?
+   * @default 'end'
+   */
+  overflowPosition?: 'start' | 'end';
 } & React.ComponentPropsWithRef<'div'>;
 
 /**
@@ -52,7 +57,14 @@ export type ButtonGroupProps = {
  */
 export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
   (props, ref) => {
-    const { children, className, style, overflowButton, ...rest } = props;
+    const {
+      children,
+      className,
+      style,
+      overflowButton,
+      overflowPosition = 'end',
+      ...rest
+    } = props;
 
     const items = React.useMemo(
       () => React.Children.map(children, (child) => <div>{child}</div>) ?? [],
@@ -73,8 +85,13 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       >
         {!!overflowButton && visibleCount < items.length ? (
           <>
+            {overflowPosition === 'start' && (
+              <div>{overflowButton(visibleCount)}</div>
+            )}
             {items.slice(0, visibleCount - 1)}
-            {overflowButton(visibleCount)}
+            {overflowPosition === 'end' && (
+              <div>{overflowButton(visibleCount)}</div>
+            )}
           </>
         ) : (
           items

--- a/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/src/core/ButtonGroup/ButtonGroup.tsx
@@ -13,11 +13,13 @@ export type ButtonGroupProps = {
    */
   children: React.ReactNode;
   /**
-   * If specified, this prop will be used to show a custom button as the last button
-   * when overflow happens, i.e. when there is not enough space to fit all the buttons.
+   * If specified, this prop will be used to show a custom button when overflow happens,
+   * i.e. when there is not enough space to fit all the buttons.
    *
    * Expects a function that takes the index of the first button that is overflowing (i.e. hidden)
    * and returns the `ReactNode` to render.
+   *
+   * The placement of this button can be controlled using the `overflowPosition` prop.
    */
   overflowButton?: (firstOverflowingIndex: number) => React.ReactNode;
   /**

--- a/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/src/core/ButtonGroup/ButtonGroup.tsx
@@ -85,11 +85,13 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       >
         {!!overflowButton && visibleCount < items.length ? (
           <>
-            {overflowPosition === 'start' && (
+            {overflowButton && overflowPosition === 'start' && (
               <div>{overflowButton(visibleCount)}</div>
             )}
+
             {items.slice(0, visibleCount - 1)}
-            {overflowPosition === 'end' && (
+
+            {overflowButton && overflowPosition === 'end' && (
               <div>{overflowButton(visibleCount)}</div>
             )}
           </>

--- a/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/src/core/ButtonGroup/ButtonGroup.tsx
@@ -19,14 +19,14 @@ export type ButtonGroupProps = {
    * Expects a function that takes the index of the first button that is overflowing (i.e. hidden)
    * and returns the `ReactNode` to render.
    *
-   * The placement of this button can be controlled using the `overflowPosition` prop.
+   * The placement of this button can be controlled using the `overflowPlacement` prop.
    */
   overflowButton?: (firstOverflowingIndex: number) => React.ReactNode;
   /**
    * If `overflowButton` is specified, should it placed at the start or the end?
    * @default 'end'
    */
-  overflowPosition?: 'start' | 'end';
+  overflowPlacement?: 'start' | 'end';
 } & React.ComponentPropsWithRef<'div'>;
 
 /**
@@ -64,7 +64,7 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       className,
       style,
       overflowButton,
-      overflowPosition = 'end',
+      overflowPlacement = 'end',
       ...rest
     } = props;
 
@@ -87,13 +87,13 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       >
         {!!overflowButton && visibleCount < items.length ? (
           <>
-            {overflowButton && overflowPosition === 'start' && (
+            {overflowButton && overflowPlacement === 'start' && (
               <div>{overflowButton(visibleCount)}</div>
             )}
 
             {items.slice(0, visibleCount - 1)}
 
-            {overflowButton && overflowPosition === 'end' && (
+            {overflowButton && overflowPlacement === 'end' && (
               <div>{overflowButton(visibleCount)}</div>
             )}
           </>

--- a/stories/core/Buttons/ButtonGroup.stories.tsx
+++ b/stories/core/Buttons/ButtonGroup.stories.tsx
@@ -102,19 +102,22 @@ export const Overflow: Story<ButtonGroupProps> = (args) => {
                     );
                   })
               }
-              {...args}
             >
               <IconButton onClick={() => action('Clicked on overflow icon')()}>
                 <SvgMore />
               </IconButton>
             </DropdownMenu>
           )}
+          {...args}
         >
           {buttons}
         </ButtonGroup>
       </div>
     </>
   );
+};
+Overflow.args = {
+  overflowPosition: 'end',
 };
 Overflow.parameters = {
   creevey: {

--- a/stories/core/Buttons/ButtonGroup.stories.tsx
+++ b/stories/core/Buttons/ButtonGroup.stories.tsx
@@ -117,7 +117,7 @@ export const Overflow: Story<ButtonGroupProps> = (args) => {
   );
 };
 Overflow.args = {
-  overflowPosition: 'end',
+  overflowPlacement: 'end',
 };
 Overflow.parameters = {
   creevey: {


### PR DESCRIPTION
New `overflowPlacement` prop allows placing overflowButton at the start.
![image](https://user-images.githubusercontent.com/9084735/152835087-b9c67da6-9c04-4875-8520-38c363d5e46c.png)

Closes #531

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] Add component features demo in Storybook (different stories)
- [x] ~~Approve test images for new stories~~
- [x] Add screenshots of the key elements of the component