### PR TITLE
fix(Slider): Handle pointermove events only when thumb is active

### DIFF
--- a/src/core/ColorPicker/ColorBuilder.tsx
+++ b/src/core/ColorPicker/ColorBuilder.tsx
@@ -210,10 +210,13 @@ export const ColorBuilder = React.forwardRef(
 
     const handleSquarePointerLeave = React.useCallback(
       (event: PointerEvent): void => {
+        if (!colorDotActive) {
+          return;
+        }
         updateSquareValue(event, 'onChange');
         setColorDotActive(false);
       },
-      [updateSquareValue],
+      [colorDotActive, updateSquareValue],
     );
     useEventListener(
       'pointerleave',

--- a/src/core/ColorPicker/ColorBuilder.tsx
+++ b/src/core/ColorPicker/ColorBuilder.tsx
@@ -173,45 +173,40 @@ export const ColorBuilder = React.forwardRef(
       },
       [colorDotActive, updateColorDot],
     );
-
     const handleSquarePointerUp = React.useCallback(
       (event: PointerEvent) => {
+        if (!colorDotActive) {
+          return;
+        }
         updateSquareValue(event, 'onChange');
         setColorDotActive(false);
         event.preventDefault();
         event.stopPropagation();
       },
-      [updateSquareValue],
+      [colorDotActive, updateSquareValue],
+    );
+    useEventListener(
+      'pointerup',
+      handleSquarePointerUp,
+      builderRef.current?.ownerDocument,
     );
 
     const handleSquarePointerMove = React.useCallback(
       (event: PointerEvent): void => {
+        if (!colorDotActive) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         updateSquareValue(event, 'onUpdate');
       },
-      [updateSquareValue],
+      [colorDotActive, updateSquareValue],
     );
-
-    React.useEffect(() => {
-      if (colorDotActive) {
-        squareRef.current?.ownerDocument.addEventListener(
-          'pointermove',
-          handleSquarePointerMove,
-        );
-        squareRef.current?.ownerDocument.addEventListener(
-          'pointerup',
-          (e) => {
-            handleSquarePointerUp(e);
-            squareRef.current?.ownerDocument.removeEventListener(
-              'pointermove',
-              handleSquarePointerMove,
-            );
-          },
-          { once: true },
-        );
-      }
-    }, [colorDotActive, handleSquarePointerMove, handleSquarePointerUp]);
+    useEventListener(
+      'pointermove',
+      handleSquarePointerMove,
+      builderRef.current?.ownerDocument,
+    );
 
     const handleSquarePointerLeave = React.useCallback(
       (event: PointerEvent): void => {

--- a/src/core/ColorPicker/ColorBuilder.tsx
+++ b/src/core/ColorPicker/ColorBuilder.tsx
@@ -175,12 +175,15 @@ export const ColorBuilder = React.forwardRef(
     );
     const handleSquarePointerUp = React.useCallback(
       (event: PointerEvent) => {
+        if (!colorDotActive) {
+          return;
+        }
         updateSquareValue(event, 'onChange');
         setColorDotActive(false);
         event.preventDefault();
         event.stopPropagation();
       },
-      [updateSquareValue],
+      [colorDotActive, updateSquareValue],
     );
     useEventListener(
       'pointerup',
@@ -190,11 +193,14 @@ export const ColorBuilder = React.forwardRef(
 
     const handleSquarePointerMove = React.useCallback(
       (event: PointerEvent): void => {
+        if (!colorDotActive) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         updateSquareValue(event, 'onUpdate');
       },
-      [updateSquareValue],
+      [colorDotActive, updateSquareValue],
     );
     useEventListener(
       'pointermove',

--- a/src/core/ColorPicker/ColorBuilder.tsx
+++ b/src/core/ColorPicker/ColorBuilder.tsx
@@ -173,40 +173,45 @@ export const ColorBuilder = React.forwardRef(
       },
       [colorDotActive, updateColorDot],
     );
+
     const handleSquarePointerUp = React.useCallback(
       (event: PointerEvent) => {
-        if (!colorDotActive) {
-          return;
-        }
         updateSquareValue(event, 'onChange');
         setColorDotActive(false);
         event.preventDefault();
         event.stopPropagation();
       },
-      [colorDotActive, updateSquareValue],
-    );
-    useEventListener(
-      'pointerup',
-      handleSquarePointerUp,
-      builderRef.current?.ownerDocument,
+      [updateSquareValue],
     );
 
     const handleSquarePointerMove = React.useCallback(
       (event: PointerEvent): void => {
-        if (!colorDotActive) {
-          return;
-        }
         event.preventDefault();
         event.stopPropagation();
         updateSquareValue(event, 'onUpdate');
       },
-      [colorDotActive, updateSquareValue],
+      [updateSquareValue],
     );
-    useEventListener(
-      'pointermove',
-      handleSquarePointerMove,
-      builderRef.current?.ownerDocument,
-    );
+
+    React.useEffect(() => {
+      if (colorDotActive) {
+        squareRef.current?.ownerDocument.addEventListener(
+          'pointermove',
+          handleSquarePointerMove,
+        );
+        squareRef.current?.ownerDocument.addEventListener(
+          'pointerup',
+          (e) => {
+            handleSquarePointerUp(e);
+            squareRef.current?.ownerDocument.removeEventListener(
+              'pointermove',
+              handleSquarePointerMove,
+            );
+          },
+          { once: true },
+        );
+      }
+    }, [colorDotActive, handleSquarePointerMove, handleSquarePointerUp]);
 
     const handleSquarePointerLeave = React.useCallback(
       (event: PointerEvent): void => {

--- a/src/core/Slider/Slider.test.tsx
+++ b/src/core/Slider/Slider.test.tsx
@@ -714,3 +714,18 @@ it('should activate thumb on pointerDown and move to closest step on move/ no up
   expect(thumbs[0].getAttribute('aria-valuenow')).toEqual('40');
   expect(thumbs[1].getAttribute('aria-valuenow')).toEqual('80');
 });
+
+it('should not break pointer events when thumb is released', () => {
+  const { container } = render(
+    <Slider min={0} max={100} values={[20, 80]} step={1} />,
+  );
+
+  assertBaseElement(container);
+  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
+  expect(thumb).not.toHaveClass('iui-active');
+
+  act(() => {
+    // userEvent.pointer is not released yet 😕
+  });
+  // expect(thumb).toHaveClass('iui-active');
+});

--- a/src/core/Slider/Slider.test.tsx
+++ b/src/core/Slider/Slider.test.tsx
@@ -714,18 +714,3 @@ it('should activate thumb on pointerDown and move to closest step on move/ no up
   expect(thumbs[0].getAttribute('aria-valuenow')).toEqual('40');
   expect(thumbs[1].getAttribute('aria-valuenow')).toEqual('80');
 });
-
-it('should not break pointer events when thumb is released', () => {
-  const { container } = render(
-    <Slider min={0} max={100} values={[20, 80]} step={1} />,
-  );
-
-  assertBaseElement(container);
-  const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
-  expect(thumb).not.toHaveClass('iui-active');
-
-  act(() => {
-    // userEvent.pointer is not released yet 😕
-  });
-  // expect(thumb).toHaveClass('iui-active');
-});

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -304,11 +304,14 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     const handlePointerMove = React.useCallback(
       (event: PointerEvent): void => {
+        if (activeThumbIndex === undefined) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         updateThumbValue(event, 'onUpdate');
       },
-      [updateThumbValue],
+      [activeThumbIndex, updateThumbValue],
     );
 
     // function called by Thumb keyboard processing
@@ -331,12 +334,15 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     const handlePointerUp = React.useCallback(
       (event: PointerEvent) => {
+        if (activeThumbIndex === undefined) {
+          return;
+        }
         updateThumbValue(event, 'onChange');
         setActiveThumbIndex(undefined);
         event.preventDefault();
         event.stopPropagation();
       },
-      [updateThumbValue],
+      [activeThumbIndex, updateThumbValue],
     );
 
     const handlePointerDownOnSlider = React.useCallback(

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from 'classnames';
 import React from 'react';
-import {
-  useTheme,
-  CommonProps,
-  getBoundedValue,
-  useEventListener,
-} from '../utils';
+import { useTheme, CommonProps, getBoundedValue } from '../utils';
 import '@itwin/itwinui-css/css/slider.css';
 import { TooltipProps } from '../Tooltip';
 import { Track } from './Track';

--- a/src/core/Slider/Slider.tsx
+++ b/src/core/Slider/Slider.tsx
@@ -304,14 +304,11 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     const handlePointerMove = React.useCallback(
       (event: PointerEvent): void => {
-        if (activeThumbIndex === undefined) {
-          return;
-        }
         event.preventDefault();
         event.stopPropagation();
         updateThumbValue(event, 'onUpdate');
       },
-      [activeThumbIndex, updateThumbValue],
+      [updateThumbValue],
     );
 
     // function called by Thumb keyboard processing
@@ -328,21 +325,36 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
       [currentValues, onChange],
     );
 
-    const onThumbActivated = React.useCallback((index: number) => {
-      setActiveThumbIndex(index);
-    }, []);
-
     const handlePointerUp = React.useCallback(
       (event: PointerEvent) => {
-        if (activeThumbIndex === undefined) {
-          return;
-        }
         updateThumbValue(event, 'onChange');
         setActiveThumbIndex(undefined);
         event.preventDefault();
         event.stopPropagation();
       },
-      [activeThumbIndex, updateThumbValue],
+      [updateThumbValue],
+    );
+
+    const onThumbActivated = React.useCallback(
+      (index: number) => {
+        setActiveThumbIndex(index);
+        containerRef.current?.ownerDocument.addEventListener(
+          'pointermove',
+          handlePointerMove,
+        );
+        containerRef.current?.ownerDocument.addEventListener(
+          'pointerup',
+          (e) => {
+            handlePointerUp(e);
+            containerRef.current?.ownerDocument.removeEventListener(
+              'pointermove',
+              handlePointerMove,
+            );
+          },
+          { once: true },
+        );
+      },
+      [handlePointerMove, handlePointerUp],
     );
 
     const handlePointerDownOnSlider = React.useCallback(
@@ -374,17 +386,6 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         }
       },
       [min, max, step, currentValues, getAllowableThumbRange, onChange],
-    );
-
-    useEventListener(
-      'pointermove',
-      handlePointerMove,
-      containerRef.current?.ownerDocument,
-    );
-    useEventListener(
-      'pointerup',
-      handlePointerUp,
-      containerRef.current?.ownerDocument,
     );
 
     const tickMarkArea = React.useMemo(() => {


### PR DESCRIPTION
Returning early when thumb is undefined so that it doesn't break other pointer event listeners on document.

Fixes #511

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~