### PR TITLE
fix(Popover): Prevents from adding 5px padding

### DIFF
--- a/src/core/utils/components/Popover.tsx
+++ b/src/core/utils/components/Popover.tsx
@@ -63,13 +63,6 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     arrow: false,
     duration: 0,
     interactive: true,
-    popperOptions: {
-      strategy: 'fixed',
-      modifiers: [
-        { name: 'flip' },
-        { name: 'preventOverflow', options: { padding: 0 } },
-      ],
-    },
     role: undefined,
     offset: [0, 0],
     maxWidth: '',
@@ -80,6 +73,15 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
       hideOnEscOrTab,
       ...(props.plugins || []),
     ],
+    popperOptions: {
+      strategy: 'fixed',
+      ...props.popperOptions,
+      modifiers: [
+        { name: 'flip' },
+        { name: 'preventOverflow', options: { padding: 0 } },
+        ...(props.popperOptions?.modifiers || []),
+      ],
+    },
   };
 
   if (props.render) {

--- a/src/core/utils/components/Popover.tsx
+++ b/src/core/utils/components/Popover.tsx
@@ -65,7 +65,10 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     interactive: true,
     popperOptions: {
       strategy: 'fixed',
-      modifiers: [{ name: 'flip' }],
+      modifiers: [
+        { name: 'flip' },
+        { name: 'preventOverflow', options: { padding: 0 } },
+      ],
     },
     role: undefined,
     offset: [0, 0],


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Fixes the issue when `Select` or any other component with `Popover` is close to the side of container, it gets 5px padding which appear isn't random.
Popper documentation: https://popper.js.org/docs/v2/modifiers/prevent-overflow/
Issue in Popper that helped to figure it out: https://github.com/floating-ui/floating-ui/issues/704
![image](https://user-images.githubusercontent.com/36186912/152374523-c926378b-efc2-477b-93e1-f1aeee0d4d24.png)


## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
