### PR TITLE
chore(deps): Bump itwinui-css to 0.47.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "^0.46.1",
+    "@itwin/itwinui-css": "^0.47.0",
     "@itwin/itwinui-icons-react": "^1.5.0",
     "@itwin/itwinui-illustrations-react": "^1.0.1",
     "@tippyjs/react": "^4.2.5",

--- a/src/core/Badge/Badge.test.tsx
+++ b/src/core/Badge/Badge.test.tsx
@@ -25,7 +25,7 @@ it('should set inline background color correctly', () => {
 
   const badge = container.querySelector('.iui-badge') as HTMLElement;
   expect(badge.textContent).toBe('label');
-  expect(badge.style.getPropertyValue('--badge-color')).toEqual(
+  expect(badge.style.getPropertyValue('--iui-badge-background-color')).toEqual(
     SoftBackgrounds.skyblue,
   );
 });
@@ -39,14 +39,18 @@ it.each([
   const { container } = render(<Badge backgroundColor={key}>label</Badge>);
   const badge = container.querySelector('.iui-badge') as HTMLElement;
   expect(badge.textContent).toBe('label');
-  expect(badge.style.getPropertyValue('--badge-color')).toEqual(value);
+  expect(badge.style.getPropertyValue('--iui-badge-background-color')).toEqual(
+    value,
+  );
 });
 
 it('should work with custom colors', () => {
   const { container } = render(<Badge backgroundColor={'pink'}>label</Badge>);
   const badge = container.querySelector('.iui-badge') as HTMLElement;
   expect(badge.textContent).toBe('label');
-  expect(badge.style.getPropertyValue('--badge-color')).toEqual('pink');
+  expect(badge.style.getPropertyValue('--iui-badge-background-color')).toEqual(
+    'pink',
+  );
 });
 
 it('should add className and style correctly', () => {

--- a/src/core/Badge/Badge.tsx
+++ b/src/core/Badge/Badge.tsx
@@ -72,8 +72,13 @@ export const Badge = (props: BadgeProps) => {
 
   const _style =
     backgroundColor &&
-    getWindow()?.CSS?.supports?.(`--badge-color: ${backgroundColor}`)
-      ? { '--badge-color': getBadgeColorValue(backgroundColor), ...style }
+    getWindow()?.CSS?.supports?.(
+      `--iui-badge-background-color: ${backgroundColor}`,
+    )
+      ? {
+          '--iui-badge-background-color': getBadgeColorValue(backgroundColor),
+          ...style,
+        }
       : { backgroundColor: getBadgeColorValue(backgroundColor), ...style };
 
   return (

--- a/src/core/ColorPicker/ColorBuilder.tsx
+++ b/src/core/ColorPicker/ColorBuilder.tsx
@@ -69,29 +69,28 @@ export const ColorBuilder = React.forwardRef(
     const [colorDotActive, setColorDotActive] = React.useState(false);
     const hueColorString = hueSliderColor.toHexString();
     const colorSquareStyle = getWindow()?.CSS?.supports?.(
-      `--hue: ${hueColorString}`,
+      `--iui-color-field-hue: ${hueColorString}`,
     )
       ? {
-          '--hue': hueColorString,
-          '--selected-color': dotColorString,
+          '--iui-color-field-hue': hueColorString,
+          '--iui-color-picker-selected-color': dotColorString,
         }
       : { backgroundColor: hueColorString };
 
     const opacitySliderStyle = getWindow()?.CSS?.supports?.(
-      `--selected-color: ${hueColorString}`,
+      `--iui-color-picker-selected-color: ${hueColorString}`,
     )
-      ? { '--selected-color': hueColorString }
+      ? { '--iui-color-picker-selected-color': hueColorString }
       : { backgroundColor: hueColorString };
 
     const squareTop = 100 - hsvColor.v;
     const squareLeft = hsvColor.s;
 
     const colorDotStyle = getWindow()?.CSS?.supports?.(
-      `--top: ${squareTop.toString()}%`,
+      `--iui-color-dot-inset: 0`,
     )
       ? {
-          '--top': squareTop.toString() + '%',
-          '--left': squareLeft.toString() + '%',
+          '--iui-color-dot-inset': `${squareTop.toString()}% auto auto ${squareLeft.toString()}%`,
         }
       : {
           backgroundColor: dotColorString,

--- a/src/core/ColorPicker/ColorPalette.test.tsx
+++ b/src/core/ColorPicker/ColorPalette.test.tsx
@@ -38,7 +38,9 @@ it('should render in its most basic state', () => {
   const palette = container.querySelector('.iui-color-palette') as HTMLElement;
 
   palette.querySelectorAll('.iui-color-swatch').forEach((swatch, index) => {
-    expect(swatch).toHaveStyle(`--swatch-color: ${expectedStyleString[index]}`);
+    expect(swatch).toHaveStyle(
+      `--iui-color-swatch-background: ${expectedStyleString[index]}`,
+    );
     expect(swatch).toHaveAttribute('tabindex', index === 0 ? '0' : '-1');
   });
 });
@@ -67,7 +69,9 @@ it('should render with selectedColor', () => {
   const palette = container.querySelector('.iui-color-palette') as HTMLElement;
 
   palette.querySelectorAll('.iui-color-swatch').forEach((swatch, index) => {
-    expect(swatch).toHaveStyle(`--swatch-color: ${expectedStyleString[index]}`);
+    expect(swatch).toHaveStyle(
+      `--iui-color-swatch-background: ${expectedStyleString[index]}`,
+    );
     if (index === 1) {
       expect(swatch).toHaveClass('iui-active');
       expect(swatch).toHaveAttribute('tabindex', '0');
@@ -102,7 +106,9 @@ it('should render with selectedColor 0', () => {
   const palette = container.querySelector('.iui-color-palette') as HTMLElement;
 
   palette.querySelectorAll('.iui-color-swatch').forEach((swatch, index) => {
-    expect(swatch).toHaveStyle(`--swatch-color: ${expectedStyleString[index]}`);
+    expect(swatch).toHaveStyle(
+      `--iui-color-swatch-background: ${expectedStyleString[index]}`,
+    );
     if (index === 0) {
       expect(swatch).toHaveClass('iui-active');
       expect(swatch).toHaveAttribute('tabindex', '0');
@@ -218,7 +224,9 @@ it('should propagate misc props correctly', () => {
       expect(child).toHaveClass('custom-child');
       expect(child).toHaveAttribute('tabindex', '0');
     } else {
-      expect(child).toHaveStyle(`--swatch-color: ${colors[index + 1]}`);
+      expect(child).toHaveStyle(
+        `--iui-color-swatch-background: ${colors[index + 1]}`,
+      );
       expect(child).toHaveAttribute('tabindex', '-1');
     }
   });

--- a/src/core/ColorPicker/ColorPicker.test.tsx
+++ b/src/core/ColorPicker/ColorPicker.test.tsx
@@ -428,9 +428,6 @@ it('should preserve hue when color dot is black/at bottom of square', () => {
   expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
     '98.4% auto auto 75%',
   );
-  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
-    '98.4% auto auto 75%',
-  );
 
   // Go to bottom of square and hue should be preserved
   fireEvent.keyDown(colorDot, { key: 'ArrowDown' });

--- a/src/core/ColorPicker/ColorPicker.test.tsx
+++ b/src/core/ColorPicker/ColorPicker.test.tsx
@@ -128,7 +128,9 @@ it('should set the selected color', () => {
   const colorBuilder = container.querySelector(
     '.iui-color-picker .iui-color-field',
   ) as HTMLElement;
-  expect(colorBuilder).toHaveStyle('--hue: #ffb300; --selected-color: #ffb300');
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-field-hue: #ffb300; --iui-color-picker-selected-color: #ffb300',
+  );
 });
 
 it('should set the dot positions', () => {
@@ -144,8 +146,9 @@ it('should set the dot positions', () => {
   //Set the correct position on color square
   const colorDot = container.querySelector('.iui-color-dot') as HTMLElement;
   expect(colorDot).toBeTruthy();
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('100%');
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('0%');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '0% auto auto 100%',
+  );
 
   // Set the correct position on the slider
   const sliderDot = container.querySelectorAll(
@@ -179,7 +182,9 @@ it('should handle arrow key navigation on hue slider dot', () => {
   const colorBuilder = container.querySelector(
     '.iui-color-picker .iui-color-field',
   ) as HTMLElement;
-  expect(colorBuilder).toHaveStyle('--hue: #ff0000; --selected-color: #ff0000');
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-field-hue: #ff0000; --iui-color-picker-selected-color: #ff0000',
+  );
 
   const sliderDot = container.querySelector('.iui-slider-thumb') as HTMLElement;
   expect(sliderDot).toBeTruthy();
@@ -192,7 +197,7 @@ it('should handle arrow key navigation on hue slider dot', () => {
   expect(sliderDot.style.getPropertyValue('left')).toEqual(
     '0.5571030640668524%',
   );
-  expect(colorBuilder).toHaveStyle('--hue: #ff0800');
+  expect(colorBuilder).toHaveStyle('--iui-color-field-hue: #ff0800');
 
   // Go left
   fireEvent.keyDown(sliderDot, { key: 'ArrowLeft' });
@@ -200,7 +205,7 @@ it('should handle arrow key navigation on hue slider dot', () => {
   expect(sliderDot.style.getPropertyValue('left')).toEqual(
     '0.2785515320334262%',
   );
-  expect(colorBuilder).toHaveStyle('--hue: #ff0400');
+  expect(colorBuilder).toHaveStyle('--iui-color-field-hue: #ff0400');
 
   // Go left to edge
   fireEvent.keyDown(sliderDot, { key: 'ArrowLeft' });
@@ -227,7 +232,9 @@ it('should handle arrow key navigation on color dot', () => {
     '.iui-color-picker .iui-color-field',
   ) as HTMLElement;
 
-  expect(colorBuilder).toHaveStyle('--hue: #ff0000; --selected-color: #ff0000');
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-field-hue: #ff0000; --iui-color-picker-selected-color: #ff0000',
+  );
 
   const sliderDot = container.querySelector('.iui-slider-thumb') as HTMLElement;
   expect(sliderDot).toBeTruthy();
@@ -235,26 +242,33 @@ it('should handle arrow key navigation on color dot', () => {
 
   const colorDot = container.querySelector('.iui-color-dot') as HTMLElement;
   expect(colorDot).toBeTruthy();
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('100%');
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('0%');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '0% auto auto 100%',
+  );
 
   // Go down
   fireEvent.keyDown(colorDot, { key: 'ArrowDown' });
   fireEvent.keyDown(colorDot, { key: 'ArrowDown' });
   expect(onChange).toHaveBeenCalledTimes(2);
   expect(onChangeComplete).not.toHaveBeenCalled();
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('2%');
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('100%');
-  expect(colorBuilder).toHaveStyle('--selected-color: #fa0000');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '2% auto auto 100%',
+  );
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-picker-selected-color: #fa0000',
+  );
   fireEvent.keyUp(colorDot, { key: 'ArrowDown' });
   expect(onChangeComplete).toHaveBeenCalledTimes(1);
 
   // Go left
   fireEvent.keyDown(colorDot, { key: 'ArrowLeft' });
   expect(onChange).toHaveBeenCalledTimes(3);
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('2%');
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('99%');
-  expect(colorBuilder).toHaveStyle('--selected-color: #fa0202');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '2% auto auto 99%',
+  );
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-picker-selected-color: #fa0202',
+  );
 
   fireEvent.keyUp(colorDot, { key: 'ArrowLeft' });
   expect(onChangeComplete).toHaveBeenCalledTimes(2);
@@ -262,30 +276,42 @@ it('should handle arrow key navigation on color dot', () => {
   // Go up to top
   fireEvent.keyDown(colorDot, { key: 'ArrowUp' });
   fireEvent.keyDown(colorDot, { key: 'ArrowUp' });
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('0%');
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('99%');
-  expect(colorBuilder).toHaveStyle('--selected-color: #ff0303');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '0% auto auto 99%',
+  );
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-picker-selected-color: #ff0303',
+  );
 
   fireEvent.keyDown(colorDot, { key: 'ArrowUp' });
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('0%');
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('99%');
-  expect(colorBuilder).toHaveStyle('--selected-color: #ff0303');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '0% auto auto 99%',
+  );
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-picker-selected-color: #ff0303',
+  );
   fireEvent.keyUp(colorDot, { key: 'ArrowUp' });
   expect(onChangeComplete).toHaveBeenCalledTimes(3);
 
   // Go right to the edge
   fireEvent.keyDown(colorDot, { key: 'ArrowRight' });
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('0%');
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('100%');
-  expect(colorBuilder).toHaveStyle('--selected-color: #ff0000');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '0% auto auto 100%',
+  );
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-picker-selected-color: #ff0000',
+  );
   fireEvent.keyUp(colorDot, { key: 'ArrowRight' });
   expect(onChangeComplete).toHaveBeenCalledTimes(4);
 
   // Go up
   fireEvent.keyDown(colorDot, { key: 'ArrowUp' });
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('0%');
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('100%');
-  expect(colorBuilder).toHaveStyle('--selected-color: #ff0000');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '0% auto auto 100%',
+  );
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-picker-selected-color: #ff0000',
+  );
   fireEvent.keyUp(colorDot, { key: 'ArrowUp' });
   expect(onChangeComplete).toHaveBeenCalledTimes(5);
 });
@@ -390,22 +416,31 @@ it('should preserve hue when color dot is black/at bottom of square', () => {
   const colorBuilder = container.querySelector(
     '.iui-color-picker .iui-color-field',
   ) as HTMLElement;
-  expect(colorBuilder.style.getPropertyValue('--selected-color')).toBe(
-    '#010402',
+  expect(
+    colorBuilder.style.getPropertyValue('--iui-color-picker-selected-color'),
+  ).toBe('#010402');
+  expect(colorBuilder.style.getPropertyValue('--iui-color-field-hue')).toBe(
+    '#00ff55',
   );
-  expect(colorBuilder.style.getPropertyValue('--hue')).toBe('#00ff55');
 
   const colorDot = container.querySelector('.iui-color-dot') as HTMLElement;
   expect(colorDot).toBeTruthy();
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('75%');
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('98.4%');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '98.4% auto auto 75%',
+  );
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '98.4% auto auto 75%',
+  );
 
   // Go to bottom of square and hue should be preserved
   fireEvent.keyDown(colorDot, { key: 'ArrowDown' });
   fireEvent.keyDown(colorDot, { key: 'ArrowDown' });
-  expect(colorDot.style.getPropertyValue('--left')).toEqual('75%');
-  expect(colorDot.style.getPropertyValue('--top')).toEqual('100%');
-  expect(colorBuilder.style.getPropertyValue('--hue')).toBe('#00ff55');
+  expect(colorDot.style.getPropertyValue('--iui-color-dot-inset')).toEqual(
+    '100% auto auto 75%',
+  );
+  expect(colorBuilder.style.getPropertyValue('--iui-color-field-hue')).toBe(
+    '#00ff55',
+  );
 });
 
 it('should set focus if setFocus is true', () => {
@@ -469,7 +504,9 @@ it('should handle arrow key navigation on opacity slider dot', () => {
   const colorBuilder = container.querySelector(
     '.iui-color-picker .iui-color-field',
   ) as HTMLElement;
-  expect(colorBuilder).toHaveStyle('--hue: #ff0000; --selected-color: #ff0000');
+  expect(colorBuilder).toHaveStyle(
+    '--iui-color-field-hue: #ff0000; --iui-color-picker-selected-color: #ff0000',
+  );
 
   const opacityDot = container.querySelectorAll(
     '.iui-slider-thumb',
@@ -510,7 +547,9 @@ it('should render color picker and handle onChangeCompleted when alpha is false'
 
   expect(
     container.querySelector('.iui-color-picker .iui-color-field'),
-  ).toHaveStyle('--hue: #ff0000; --selected-color: #ff0000');
+  ).toHaveStyle(
+    '--iui-color-field-hue: #ff0000; --iui-color-picker-selected-color: #ff0000',
+  );
   expect(container.querySelector('.iui-hue-slider')).toBeTruthy();
   expect(container.querySelector('.iui-opacity-slider')).toBeFalsy();
   expect(container.querySelector('.iui-color-input-wrapper')).toBeTruthy();

--- a/src/core/ColorPicker/ColorSwatch.test.tsx
+++ b/src/core/ColorPicker/ColorSwatch.test.tsx
@@ -57,13 +57,15 @@ it('should render active color swatch', () => {
   expect(swatch?.classList).toContain('iui-active');
 });
 
-it('should set --swatch-color', () => {
+it('should set --iui-color-swatch-background', () => {
   window.CSS = { supports: () => true, escape: (i) => i };
 
   const { container } = render(<ColorSwatch color={'#9BA5AF'} />);
   const swatch = container.querySelector('.iui-color-swatch') as HTMLElement;
   expect(swatch).toBeTruthy();
-  expect(swatch.style.getPropertyValue('--swatch-color')).toEqual('#9BA5AF');
+  expect(
+    swatch.style.getPropertyValue('--iui-color-swatch-background'),
+  ).toEqual('#9BA5AF');
 });
 
 it('should handle color swatch onClick', () => {

--- a/src/core/ColorPicker/ColorSwatch.tsx
+++ b/src/core/ColorPicker/ColorSwatch.tsx
@@ -40,8 +40,10 @@ export const ColorSwatch = React.forwardRef<HTMLDivElement, ColorSwatchProps>(
 
     const _style = React.useMemo(
       () =>
-        getWindow()?.CSS?.supports?.(`--swatch-color: ${colorString}`)
-          ? { '--swatch-color': colorString, ...style }
+        getWindow()?.CSS?.supports?.(
+          `--iui-color-swatch-background: ${colorString}`,
+        )
+          ? { '--iui-color-swatch-background': colorString, ...style }
           : { backgroundColor: colorString, ...style },
       [colorString, style],
     );

--- a/src/core/Table/TablePaginator.tsx
+++ b/src/core/Table/TablePaginator.tsx
@@ -158,20 +158,19 @@ export const TablePaginator = (props: TablePaginatorProps) => {
 
   const pageButton = React.useCallback(
     (index: number, tabIndex = index === focusedIndex ? 0 : -1) => (
-      <div key={index}>
-        <button
-          className={cx('iui-paginator-page-button', {
-            'iui-active': index === currentPage,
-            'iui-paginator-page-button-small': buttonSize === 'small',
-          })}
-          onClick={() => onPageChange(index)}
-          aria-current={index === currentPage}
-          aria-label={localization.goToPageLabel(index + 1)}
-          tabIndex={tabIndex}
-        >
-          {index + 1}
-        </button>
-      </div>
+      <button
+        key={index}
+        className={cx('iui-paginator-page-button', {
+          'iui-active': index === currentPage,
+          'iui-paginator-page-button-small': buttonSize === 'small',
+        })}
+        onClick={() => onPageChange(index)}
+        aria-current={index === currentPage}
+        aria-label={localization.goToPageLabel(index + 1)}
+        tabIndex={tabIndex}
+      >
+        {index + 1}
+      </button>
     ),
     [focusedIndex, currentPage, localization, buttonSize, onPageChange],
   );
@@ -250,15 +249,13 @@ export const TablePaginator = (props: TablePaginatorProps) => {
   const showPageSizeList = pageSizeList && onPageSizeChange && !!totalRowsCount;
 
   const ellipsis = (
-    <div>
-      <span
-        className={cx('iui-paginator-ellipsis', {
-          'iui-paginator-ellipsis-small': size === 'small',
-        })}
-      >
-        …
-      </span>
-    </div>
+    <span
+      className={cx('iui-paginator-ellipsis', {
+        'iui-paginator-ellipsis-small': size === 'small',
+      })}
+    >
+      …
+    </span>
   );
 
   const noRowsContent = (

--- a/src/core/Tile/Tile.tsx
+++ b/src/core/Tile/Tile.tsx
@@ -213,8 +213,7 @@ export const Tile = (props: TileProps) => {
             menuItems={(close) =>
               moreOptions.map((option: React.ReactElement) =>
                 React.cloneElement(option, {
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  onClick: (value: any) => {
+                  onClick: (value: unknown) => {
                     close();
                     option.props.onClick?.(value);
                   },
@@ -222,16 +221,19 @@ export const Tile = (props: TileProps) => {
               )
             }
           >
-            <IconButton
-              styleType='borderless'
-              size='small'
+            <div
               className={cx('iui-tile-more-options', {
                 'iui-visible': isMenuVisible,
               })}
-              aria-label='More options'
             >
-              <SvgMore />
-            </IconButton>
+              <IconButton
+                styleType='borderless'
+                size='small'
+                aria-label='More options'
+              >
+                <SvgMore />
+              </IconButton>
+            </div>
           </DropdownMenu>
         )}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,10 +2361,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@^0.46.1":
-  version "0.46.1"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.46.1.tgz#a0143c66a5cb7bdf9231a653dab3c8532d064708"
-  integrity sha512-3X+FnGN+nQgPn+rmeCvy7EH35L+RkqgpH0Vfa5KWW1vaP2ZvzVWPGX51X7CdTozalNZiQlz/mtbDQNF8HNv8/Q==
+"@itwin/itwinui-css@^0.47.0":
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.47.0.tgz#a7097c70aee3215303022b078e2b001097780cfb"
+  integrity sha512-I6k+3LdHf6nipourmiFoxQMUSy2GgzioVB6Wi0mJwZoMdEyyEL1sU8Nm67kVneU38wCeLAtUVk28dZttcBbG1A==
 
 "@itwin/itwinui-icons-react@^1.5.0":
   version "1.5.0"


### PR DESCRIPTION
Bumped iTwinUI-css to 0.47.0 and updated CSS usage according to https://github.com/iTwin/iTwinUI/pull/476,  https://github.com/iTwin/iTwinUI/pull/448, https://github.com/iTwin/iTwinUI/pull/481 and https://github.com/iTwin/iTwinUI/pull/446.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~~Add component features demo in Storybook (different stories)~~
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
