### PR TITLE
fix(Menu): Fix lost item focus in edge cases

### DIFF
--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -53,6 +53,10 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(
     const refs = useMergedRefs(menuRef, ref);
 
     React.useEffect(() => {
+      setFocusedIndex(null);
+    }, [children]);
+
+    React.useEffect(() => {
       const items = getFocusableElements(menuRef.current);
       if (focusedIndex != null) {
         (items?.[focusedIndex] as HTMLLIElement)?.focus();
@@ -66,10 +70,6 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(
         setFocusedIndex(selectedIndex > -1 ? selectedIndex : 0);
       }
     }, [setFocus, focusedIndex]);
-
-    React.useEffect(() => {
-      setFocusedIndex(null);
-    }, [children]);
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
       const items = getFocusableElements(menuRef.current);


### PR DESCRIPTION
Some iTwinjs cases had escape button not working, becuase menu item had no focus on open. Somehow our reset was overriding the calculated value and not working.
Changing the order helped in iTwin.js, so hopefully, thats the fix.
