### PR TITLE
chore: Removing tippy for all tests

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -13,7 +13,7 @@ if (window.PointerEvent) {
   window.PointerEvent = window.MouseEvent;
 }
 
-beforeEach(() => {
+afterEach(() => {
   // Cleanup tippy so it does not stay in the DOM
   document
     .querySelectorAll('[data-tippy-root]')

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -12,3 +12,10 @@ if (window.PointerEvent) {
   // @ts-expect-error // eslint-disable-line @typescript-eslint/ban-ts-comment
   window.PointerEvent = window.MouseEvent;
 }
+
+beforeEach(() => {
+  // Cleanup tippy so it does not stay in the DOM
+  document
+    .querySelectorAll('[data-tippy-root]')
+    .forEach((tippy) => tippy.remove());
+});

--- a/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
+++ b/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
@@ -31,11 +31,6 @@ function renderComponent(props?: Partial<DropdownButtonProps>) {
   );
 }
 
-afterEach(() => {
-  // cleanup tippy after every test, so it does not stay in the dom
-  document.querySelector('[data-tippy-root]')?.remove();
-});
-
 it('should render in its most basic state', () => {
   const { container } = renderComponent();
   expect(container.querySelector('.iui-button.iui-dropdown')).toBeTruthy();

--- a/src/core/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.test.tsx
@@ -39,11 +39,6 @@ function renderComponent(props?: Partial<DropdownMenuProps>) {
   );
 }
 
-afterEach(() => {
-  // cleanup tippy after every test, so it does not stay in the dom
-  document.querySelector('[data-tippy-root]')?.remove();
-});
-
 it('should show menu only after click', () => {
   renderComponent();
 

--- a/src/core/Header/HeaderButton.test.tsx
+++ b/src/core/Header/HeaderButton.test.tsx
@@ -11,11 +11,6 @@ import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
 import HeaderButton from './HeaderButton';
 import { MenuItem } from '../Menu';
 
-afterEach(() => {
-  // cleanup tippy after every test, so it does not stay in the dom
-  document.querySelector('[data-tippy-root]')?.remove();
-});
-
 it('should render in its most basic state', () => {
   const { container } = render(<HeaderButton name='MockName' />);
   expect(

--- a/src/core/Slider/Slider.test.tsx
+++ b/src/core/Slider/Slider.test.tsx
@@ -30,11 +30,6 @@ const getBoundingClientRect = Element.prototype.getBoundingClientRect;
 const sliderContainerSize = createBoundingClientRect(10, 0, 1010, 60);
 Element.prototype.getBoundingClientRect = () => sliderContainerSize;
 
-afterEach(() => {
-  // cleanup tippy after every test, so it does not stay in the dom
-  document.querySelector('[data-tippy-root]')?.remove();
-});
-
 afterAll(() => {
   Element.prototype.getBoundingClientRect = getBoundingClientRect;
 });

--- a/src/core/Wizard/Wizard.test.tsx
+++ b/src/core/Wizard/Wizard.test.tsx
@@ -7,11 +7,6 @@ import React from 'react';
 import { Wizard } from './Wizard';
 
 describe('<Wizard />', () => {
-  afterEach(() => {
-    // cleanup tippy after every test, so it does not stay in the dom
-    document.querySelector('[data-tippy-root]')?.remove();
-  });
-
   it('should render all step names and numbers in default wizard', () => {
     const wizard = (
       <Wizard


### PR DESCRIPTION
I was debugging `Table` tests and got this when called `debug()`:
![image](https://user-images.githubusercontent.com/36186912/157635607-5afd5b01-1bef-4193-9d8e-ed230a68fc78.png)

I couldn't see any of the `Table` HTML because there were too much tippy elements.
So I placed removal of tippy in `setupTests.ts` so we wouldn't miss removal in any other test.