### PR TITLE
fix: export ToastPresentation

### DIFF
--- a/src/core/Toast/index.ts
+++ b/src/core/Toast/index.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import Toaster from './Toaster';
 export type { ToastOptions } from './Toaster';
+export { ToastPresentation } from './Toast';
 
 const toaster = new Toaster();
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -201,7 +201,7 @@ export type { TileProps } from './Tile';
 export { TimePicker } from './TimePicker';
 export type { MeridiemType, TimePickerProps } from './TimePicker';
 
-export { default as toaster } from './Toast';
+export { default as toaster, ToastPresentation } from './Toast';
 export type { ToastOptions } from './Toast';
 
 export { ThemeProvider } from './ThemeProvider';


### PR DESCRIPTION
This component is used in [ iTwin.js](https://github.com/iTwin/itwinjs-core/blob/master/ui/appui-react/src/appui-react/messages/ToastMessage.tsx#L12) multiple times. They are referencing it from its path relative to the cjs build, which precludes anybody from using the iTwin Viewer with esm. Exporting from the barrel should allow them to import properly until a more suitable solution is added.

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
