### PR TITLE
fix(ComboBox): Combine input onChange with user's prop

### DIFF
--- a/src/core/ComboBox/ComboBox.test.tsx
+++ b/src/core/ComboBox/ComboBox.test.tsx
@@ -9,6 +9,7 @@ import { ComboBox, ComboBoxProps } from './ComboBox';
 import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
 import { MenuItem } from '../Menu';
 import { StatusMessage } from '../StatusMessage';
+import userEvent from '@testing-library/user-event';
 
 const renderComponent = (props?: Partial<ComboBoxProps<number>>) => {
   return render(
@@ -422,4 +423,19 @@ it('should render with message and status', () => {
   expect(inputContainer.querySelector('.iui-input-icon')).toBeTruthy();
   const message = container.querySelector('.iui-message') as HTMLElement;
   expect(message.textContent).toBe('Text here');
+});
+
+it('should merge inputProps.onChange correctly', () => {
+  const mockOnChange = jest.fn();
+  const { container } = renderComponent({
+    inputProps: { onChange: ({ target: { value } }) => mockOnChange(value) },
+  });
+
+  assertBaseElement(container);
+  const input = container.querySelector('.iui-input') as HTMLInputElement;
+  userEvent.tab();
+  userEvent.keyboard('hi');
+
+  expect(input).toHaveValue('hi');
+  expect(mockOnChange).toHaveBeenCalledWith('hi');
 });

--- a/src/core/ComboBox/ComboBox.tsx
+++ b/src/core/ComboBox/ComboBox.tsx
@@ -422,7 +422,6 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
             ref={inputRef}
             onKeyDown={onKeyDown}
             onFocus={() => setIsOpen(true)}
-            onChange={onInput}
             value={inputValue}
             aria-activedescendant={
               isOpen && focusedIndex > -1
@@ -436,6 +435,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
             autoCapitalize='none'
             autoCorrect='off'
             {...inputProps}
+            onChange={onInput}
           />
         </Popover>
         <span


### PR DESCRIPTION
Previously, user's `onChange` was overriding ours. This change will make sure it's combined properly.

Before:
![c1](https://user-images.githubusercontent.com/9084735/159527343-adfa1ef1-49e9-44f0-8580-e3837f979058.gif)

After:
![c2](https://user-images.githubusercontent.com/9084735/159527088-83559235-2e25-41e6-90e7-afec267160fe.gif)

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
- [ ] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories)
- [ ] Approve test images for new stories
- [ ] Add screenshots of the key elements of the component
