### PR TITLE
fix(Table): Date filter makes range from the beginning to the end of the day

### DIFF
--- a/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
+++ b/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
@@ -70,8 +70,8 @@ it('should set filter when both values entered', () => {
   screen.getByText('Filter').click();
 
   expect(setFilter).toHaveBeenCalledWith([
-    new Date(2021, 4, 1),
-    new Date(2021, 4, 3),
+    new Date(2021, 4, 1, 0, 0, 0, 0),
+    new Date(2021, 4, 3, 23, 59, 59, 999),
   ]);
 });
 
@@ -88,7 +88,10 @@ it('should set filter when only From is entered', () => {
 
   screen.getByText('Filter').click();
 
-  expect(setFilter).toHaveBeenCalledWith([new Date(2021, 4, 1), undefined]);
+  expect(setFilter).toHaveBeenCalledWith([
+    new Date(2021, 4, 1, 0, 0, 0, 0),
+    undefined,
+  ]);
 });
 
 it('should set filter when only To is entered', () => {
@@ -104,7 +107,10 @@ it('should set filter when only To is entered', () => {
 
   screen.getByText('Filter').click();
 
-  expect(setFilter).toHaveBeenCalledWith([undefined, new Date(2021, 4, 3)]);
+  expect(setFilter).toHaveBeenCalledWith([
+    undefined,
+    new Date(2021, 4, 3, 23, 59, 59, 999),
+  ]);
 });
 
 it('should set filter when both values entered and Enter is pressed', () => {
@@ -125,8 +131,8 @@ it('should set filter when both values entered and Enter is pressed', () => {
   });
 
   expect(setFilter).toHaveBeenCalledWith([
-    new Date(2021, 4, 1),
-    new Date(2021, 4, 3),
+    new Date(2021, 4, 1, 0, 0, 0, 0),
+    new Date(2021, 4, 3, 23, 59, 59, 999),
   ]);
 });
 
@@ -160,4 +166,32 @@ it('should set filter with empty values when date is not fully entered', () => {
   screen.getByText('Filter').click();
 
   expect(setFilter).toHaveBeenCalledWith([undefined, undefined]);
+});
+
+it('should set filter and keep time from existing dates', () => {
+  const setFilter = jest.fn();
+  const { container } = renderComponent({
+    setFilter,
+    column: {
+      filterValue: [
+        new Date(2021, 4, 1, 10, 20, 30, 400),
+        new Date(2021, 4, 3, 20, 30, 40, 500),
+      ],
+    } as HeaderGroup,
+  });
+
+  const labeledInputs = container.querySelectorAll(
+    '.iui-input-container.iui-inline-label input',
+  ) as NodeListOf<HTMLInputElement>;
+  expect(labeledInputs.length).toBe(2);
+
+  fireEvent.change(labeledInputs[0], { target: { value: 'May 1, 2021' } });
+  fireEvent.change(labeledInputs[1], { target: { value: 'May 3, 2021' } });
+
+  screen.getByText('Filter').click();
+
+  expect(setFilter).toHaveBeenCalledWith([
+    new Date(2021, 4, 1, 10, 20, 30, 400),
+    new Date(2021, 4, 3, 20, 30, 40, 500),
+  ]);
 });

--- a/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
+++ b/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
@@ -69,9 +69,42 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
   const [from, setFrom] = React.useState<Date | undefined>(
     column.filterValue?.[0] ? new Date(column.filterValue?.[0]) : undefined,
   );
+  const onFromChange = React.useCallback((date?: Date) => {
+    setFrom((prevDate) => {
+      if (prevDate || !date) {
+        return date;
+      }
+      return new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        0,
+        0,
+        0,
+        0,
+      );
+    });
+  }, []);
+
   const [to, setTo] = React.useState<Date | undefined>(
     column.filterValue?.[1] ? new Date(column.filterValue?.[1]) : undefined,
   );
+  const onToChange = React.useCallback((date?: Date) => {
+    setTo((prevDate) => {
+      if (prevDate || !date) {
+        return date;
+      }
+      return new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        23,
+        59,
+        59,
+        999,
+      );
+    });
+  }, []);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter') {
@@ -84,7 +117,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
       <DatePickerInput
         label={translatedStrings.from}
         date={from}
-        onChange={setFrom}
+        onChange={onFromChange}
         formatDate={formatDate}
         parseInput={parseInput}
         onKeyDown={onKeyDown}
@@ -94,7 +127,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
       <DatePickerInput
         label={translatedStrings.to}
         date={to}
-        onChange={setTo}
+        onChange={onToChange}
         formatDate={formatDate}
         parseInput={parseInput}
         onKeyDown={onKeyDown}


### PR DESCRIPTION


<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

The problem is that `DatePicker` returns selected day with the current time, e.g. if current time is 17:00 and I set "From" filter to "March 24, 2022" and there is a row that has date with 'March 24, 2022, 12:00`, this row wouldn't be shown.
So my change makes date range from 00:00 to 23:59.

Closes #600

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~Add component features demo in Storybook (different stories)~
- [x] ~Approve test images for new stories~
- [x] ~Add screenshots of the key elements of the component~
