### PR TITLE
fix(Menu): Fixed keyboard navigation when MenuItem contains selectable children

### DIFF
--- a/src/core/Menu/Menu.test.tsx
+++ b/src/core/Menu/Menu.test.tsx
@@ -8,6 +8,8 @@ import MenuItem from './MenuItem';
 import Menu, { MenuProps } from './Menu';
 import { MenuDivider } from './MenuDivider';
 import { MenuExtraContent } from './MenuExtraContent';
+import { Checkbox } from '../Checkbox';
+import { Button } from '../Buttons';
 
 const testLabels = ['Test0', 'Test1', 'Test2'];
 
@@ -66,15 +68,29 @@ it('should handle keyboard navigation', () => {
     children: [
       <MenuExtraContent key={0}>Test content</MenuExtraContent>,
       <MenuItem key={1}>Test0</MenuItem>,
-      <MenuItem key={2}>Test1</MenuItem>,
+      <MenuItem key={2}>
+        <Checkbox />
+        Test1
+      </MenuItem>,
       <MenuDivider key={3} />,
       <MenuItem key={4} disabled>
         Test2
       </MenuItem>,
       <MenuItem key={5}>Test3</MenuItem>,
+      <MenuExtraContent key={6}>
+        <Button>Test4</Button>
+      </MenuExtraContent>,
     ],
   });
-  const labels = ['Test content', 'Test0', 'Test1', '', 'Test2', 'Test3'];
+  const labels = [
+    'Test content',
+    'Test0',
+    'Test1',
+    '',
+    'Test2',
+    'Test3',
+    'Test4',
+  ];
 
   const menu = container.querySelector('.iui-menu') as HTMLUListElement;
   assertBaseElement(menu, { labels, focusedIndex: 1 });
@@ -86,9 +102,19 @@ it('should handle keyboard navigation', () => {
   // Should skip separator and disabled item
   fireEvent.keyDown(menu, { key: 'ArrowDown' });
   assertBaseElement(menu, { labels, focusedIndex: 5 });
+  // Test3 -> Test4
   fireEvent.keyDown(menu, { key: 'ArrowDown' });
-  assertBaseElement(menu, { labels, focusedIndex: 5 });
+  // Extra content li element is not focused, therefore setting focusedIndex to -1
+  assertBaseElement(menu, { labels, focusedIndex: -1 });
+  expect(container.querySelector('.iui-button')).toHaveFocus();
+  // Should stay on Test4
+  fireEvent.keyDown(menu, { key: 'ArrowDown' });
+  assertBaseElement(menu, { labels, focusedIndex: -1 });
+  expect(container.querySelector('.iui-button')).toHaveFocus();
 
+  // Test4 -> Test3
+  fireEvent.keyDown(menu, { key: 'ArrowUp' });
+  assertBaseElement(menu, { labels, focusedIndex: 5 });
   // Test3 -> Test1
   fireEvent.keyDown(menu, { key: 'ArrowUp' });
   assertBaseElement(menu, { labels, focusedIndex: 2 });
@@ -96,6 +122,7 @@ it('should handle keyboard navigation', () => {
   // Should skip separator and disabled item
   fireEvent.keyDown(menu, { key: 'ArrowUp' });
   assertBaseElement(menu, { labels, focusedIndex: 1 });
+  // Should stay on Test0
   fireEvent.keyDown(menu, { key: 'ArrowUp' });
   assertBaseElement(menu, { labels, focusedIndex: 1 });
 });

--- a/src/core/Menu/Menu.test.tsx
+++ b/src/core/Menu/Menu.test.tsx
@@ -99,7 +99,7 @@ it('should handle keyboard navigation', () => {
   fireEvent.keyDown(menu, { key: 'ArrowDown' });
   assertBaseElement(menu, { labels, focusedIndex: 2 });
   // Test1 -> Test3
-  // Should skip separator and disabled item
+  // Should skip checkbox, separator and disabled item
   fireEvent.keyDown(menu, { key: 'ArrowDown' });
   assertBaseElement(menu, { labels, focusedIndex: 5 });
   // Test3 -> Test4

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -56,8 +56,16 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(
       setFocusedIndex(null);
     }, [children]);
 
+    const getFocusableNodes = React.useCallback(() => {
+      const focusableItems = getFocusableElements(menuRef.current);
+      // Filter out focusable elements that are inside each node, e.g. checkbox, anchor
+      return focusableItems.filter(
+        (i) => !focusableItems.some((p) => p.contains(i.parentElement)),
+      ) as HTMLElement[];
+    }, []);
+
     React.useEffect(() => {
-      const items = getFocusableElements(menuRef.current);
+      const items = getFocusableNodes();
       if (focusedIndex != null) {
         (items?.[focusedIndex] as HTMLLIElement)?.focus();
         return;
@@ -69,10 +77,10 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(
       if (setFocus) {
         setFocusedIndex(selectedIndex > -1 ? selectedIndex : 0);
       }
-    }, [setFocus, focusedIndex]);
+    }, [setFocus, focusedIndex, getFocusableNodes]);
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
-      const items = getFocusableElements(menuRef.current);
+      const items = getFocusableNodes();
       if (!items?.length) {
         return;
       }

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -58,7 +58,7 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(
 
     const getFocusableNodes = React.useCallback(() => {
       const focusableItems = getFocusableElements(menuRef.current);
-      // Filter out focusable elements that are inside each node, e.g. checkbox, anchor
+      // Filter out focusable elements that are inside each menu item, e.g. checkbox, anchor
       return focusableItems.filter(
         (i) => !focusableItems.some((p) => p.contains(i.parentElement)),
       ) as HTMLElement[];


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->
Keyboard navigation goes trough each focusable item that has not focusable parent (omit inner focusable content like checkbox, anchor).

Closes #379 <!-- Add issue number -->

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~Add component features demo in Storybook (different stories)~
- [x] ~Approve test images for new stories~
- [x] ~Add screenshots of the key elements of the component~
