### PR TITLE
fix(Table): Add support for `preventDefault` in row click events

### DIFF
--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -356,6 +356,18 @@ it('should not select when clicked on row but selectRowOnClick flag is false', (
   expect(onRowClick).toHaveBeenCalled();
 });
 
+it('should not select when clicked on row but preventDefault is set', () => {
+  const onSelect = jest.fn();
+  renderComponent({
+    isSelectable: true,
+    onSelect,
+    rowProps: () => ({ onClick: (e) => e.preventDefault() }),
+  });
+
+  userEvent.click(screen.getByText(mockedData()[1].name));
+  expect(onSelect).not.toHaveBeenCalled();
+});
+
 it('should not trigger onSelect when sorting and filtering', () => {
   const onSort = jest.fn();
   const onSelect = jest.fn();

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -356,7 +356,7 @@ it('should not select when clicked on row but selectRowOnClick flag is false', (
   expect(onRowClick).toHaveBeenCalled();
 });
 
-it('should not select when clicked on row but preventDefault is set', () => {
+it('should not select when clicked on row and preventDefault is set', () => {
   const onSelect = jest.fn();
   renderComponent({
     isSelectable: true,

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -491,7 +491,15 @@ export const Table = <
   const onRowClickHandler = React.useCallback(
     (event: React.MouseEvent, row: Row<T>) => {
       const isDisabled = isRowDisabled?.(row.original);
-      if (isSelectable && !isDisabled && selectRowOnClick) {
+      if (!isDisabled) {
+        onRowClick?.(event, row);
+      }
+      if (
+        isSelectable &&
+        !isDisabled &&
+        selectRowOnClick &&
+        !event.isDefaultPrevented()
+      ) {
         if (!row.isSelected && !event.ctrlKey) {
           dispatch({
             type: singleRowSelectedAction,
@@ -500,9 +508,6 @@ export const Table = <
         } else {
           row.toggleRowSelected(!row.isSelected);
         }
-      }
-      if (!isDisabled) {
-        onRowClick?.(event, row);
       }
     },
     [isRowDisabled, isSelectable, selectRowOnClick, dispatch, onRowClick],

--- a/stories/core/Table.stories.tsx
+++ b/stories/core/Table.stories.tsx
@@ -2652,6 +2652,9 @@ export const CustomizedColumns: Story<Partial<TableProps>> = (args) => {
       onExpand={onExpand}
       isSelectable
       isRowDisabled={isRowDisabled}
+      rowProps={({ index }) => ({
+        onClick: (e) => index === 0 && e.preventDefault(),
+      })}
       {...args}
     />
   );


### PR DESCRIPTION
This change makes it so our custom row click event handlers will respect user's calls to `preventDefault` by checking for `isDefaultPrevented()` before calling custom actions. Useful to prevent selection on click for individual rows.

This requires user's handler to be called first, which was already the case for `rowProps` (through `mergedProps.onClick` in `TableRowMemoized`), but I also moved the `onRowClick` handler up just in case.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] Add component features demo in Storybook (different stories)
- [x] ~~Approve test images for new stories~~
- [x] ~~Add screenshots of the key elements of the component~~
