### PR TITLE
fix(ComboBox): Use latest value of `onChange` prop

### DIFF
--- a/packages/iTwinUI-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/iTwinUI-react/src/core/ComboBox/ComboBox.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { ComboBox, ComboBoxProps } from './ComboBox';
 import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
@@ -438,4 +438,23 @@ it('should merge inputProps.onChange correctly', () => {
 
   expect(input).toHaveValue('hi');
   expect(mockOnChange).toHaveBeenCalledWith('hi');
+});
+
+it('should use the latest onChange prop', () => {
+  const mockOnChange1 = jest.fn();
+  const mockOnChange2 = jest.fn();
+  const options = [0, 1, 2].map((value) => ({ value, label: `Item ${value}` }));
+
+  const { rerender } = render(
+    <ComboBox options={options} onChange={mockOnChange1} />,
+  );
+
+  userEvent.tab();
+  screen.getByText('Item 1').click();
+  expect(mockOnChange1).toHaveBeenNthCalledWith(1, 1);
+
+  rerender(<ComboBox options={options} onChange={mockOnChange2} />);
+  screen.getByText('Item 2').click();
+  expect(mockOnChange2).toHaveBeenNthCalledWith(1, 2);
+  expect(mockOnChange1).toHaveBeenCalledTimes(1);
 });

--- a/packages/iTwinUI-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/iTwinUI-react/src/core/ComboBox/ComboBox.tsx
@@ -128,6 +128,9 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
   );
 
   const userOnChange = React.useRef(onChange);
+  React.useEffect(() => {
+    userOnChange.current = onChange;
+  }, [onChange]);
 
   const memoizedItems = React.useMemo(
     () =>
@@ -190,9 +193,8 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
   );
 
   // Maintain internal selected value state synced with `value` prop
-  const [selectedValue, setSelectedValue] = React.useState<T | undefined>(
-    value,
-  );
+  const [selectedValue, setSelectedValue] =
+    React.useState<T | undefined>(value);
   React.useEffect(() => {
     setSelectedValue(value);
   }, [value]);


### PR DESCRIPTION
Previously, the ref was locked to the very initial value of `onChange`. The useEffect ensures that we get the latest value.

Fixes #635.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~Add component features demo in Storybook (different stories)~
- [x] ~Approve test images for new stories~
- [x] ~Add screenshots of the key elements of the component~
