### PR TITLE
ci: Fix path in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,6 @@ name: CD
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,8 @@ name: CD
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   release-please:
@@ -18,6 +20,7 @@ jobs:
           release-type: node
           package-name: release-please-action
           changelog-types: '[{"type":"feat","section":"What''s new"},{"type":"fix","section":"Fixes"}]'
+          path: packages/iTwinUI-react
 
   publish:
     name: Publish npm package


### PR DESCRIPTION
release-please action needs to point to the iTwinUI-react subdirectory now.

already tested by closing the "bad" PR [#637](https://github.com/iTwin/iTwinUI-react/pull/637/commits/36cb0dca3278838e840f84785eb3274ea69cf3f1) and re-running the action, which created the correct PR #639 