### PR TITLE
chore: Fix `build-storybook` command

### DIFF
--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -43,7 +43,7 @@
     "copy-files": "cpx \"../../{README,LICENSE}.md\" .",
     "storybook": "start-storybook -p 6006",
     "dev": "yarn storybook",
-    "build-storybook": "build-storybook"
+    "build-storybook": "yarn copy-files && build-storybook"
   },
   "dependencies": {
     "@itwin/itwinui-css": "^0.55.0",


### PR DESCRIPTION
`copy-files` needs to run first for `README.md` to be used in `Overview` story.
