### PR TITLE
ci: Fix path in publish storybook workflow

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -26,4 +26,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ github.workspace }}/storybook-static/
+          publish_dir: ${{ github.workspace }}/packages/iTwinUI-react/storybook-static/


### PR DESCRIPTION
Before this change, the workflow was not uploading anything and [emptying](https://github.com/iTwin/iTwinUI-react/commit/b47acd524b00d8db5b7f61235518e3ef57b5076c) the `gh-pages` branch.