### PR TITLE
fix(Table): Fixes headless Table as previously it started to throw an error

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -2233,7 +2233,7 @@ it('should handle table resize only when some columns were resized', () => {
       triggerResize = onResize;
       return [
         jest.fn(),
-        ({ disconnect: jest.fn() } as unknown) as ResizeObserver,
+        { disconnect: jest.fn() } as unknown as ResizeObserver,
       ];
     });
   const columns: Column<TestDataType>[] = [
@@ -2579,9 +2579,8 @@ it('should render action column with column manager', () => {
   });
 
   expect(container.querySelectorAll('[role="columnheader"]').length).toBe(3);
-  const actionColumn = container.querySelectorAll<HTMLInputElement>(
-    '.iui-slot',
-  );
+  const actionColumn =
+    container.querySelectorAll<HTMLInputElement>('.iui-slot');
   expect(
     actionColumn[0].firstElementChild?.className.includes(
       'iui-button iui-borderless',
@@ -2631,9 +2630,8 @@ it('should hide column when deselected in column manager', () => {
 
   const columnManager = container.querySelector('.iui-button') as HTMLElement;
   userEvent.click(columnManager);
-  const columnManagerColumns = document.querySelectorAll<HTMLLIElement>(
-    '.iui-menu-item',
-  );
+  const columnManagerColumns =
+    document.querySelectorAll<HTMLLIElement>('.iui-menu-item');
   userEvent.click(columnManagerColumns[1]);
 
   headerCells = container.querySelectorAll<HTMLDivElement>(
@@ -2677,9 +2675,8 @@ it('should be disabled in column manager if `disableToggleVisibility` is true', 
   const columnManager = container.querySelector('.iui-button') as HTMLElement;
 
   userEvent.click(columnManager);
-  const columnManagerColumns = document.querySelectorAll<HTMLLIElement>(
-    '.iui-menu-item',
-  );
+  const columnManagerColumns =
+    document.querySelectorAll<HTMLLIElement>('.iui-menu-item');
   expect(columnManagerColumns[0].classList).toContain('iui-disabled');
 
   expect(
@@ -2765,9 +2762,8 @@ it('should add expander column manually', () => {
   const rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(3);
 
-  const expanders = container.querySelectorAll<HTMLButtonElement>(
-    '.iui-row-expander',
-  );
+  const expanders =
+    container.querySelectorAll<HTMLButtonElement>('.iui-row-expander');
   expect(expanders.length).toBe(3);
   expect(expanders[0].disabled).toBe(false);
   expect(expanders[1].disabled).toBe(true);
@@ -2879,4 +2875,25 @@ it('should render selectable rows without select column', () => {
   expect(rows[1].classList).toContain('iui-selected');
   expect(rows[2].classList).not.toContain('iui-selected');
   expect(onRowClick).toHaveBeenCalledTimes(3);
+});
+
+it('should not throw on headless table', () => {
+  const columns: Column<TestDataType>[] = [
+    {
+      id: 'name',
+      Header: 'Name',
+      accessor: 'name',
+    },
+    {
+      id: 'description',
+      Header: 'Description',
+      accessor: 'description',
+    },
+  ];
+  const { container } = renderComponent({
+    columns,
+  });
+
+  expect(container.querySelector('.iui-table-header .iui-row')).toBeFalsy();
+  expect(container.querySelector('.iui-table-body')).toBeTruthy();
 });

--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -2233,7 +2233,7 @@ it('should handle table resize only when some columns were resized', () => {
       triggerResize = onResize;
       return [
         jest.fn(),
-        { disconnect: jest.fn() } as unknown as ResizeObserver,
+        ({ disconnect: jest.fn() } as unknown) as ResizeObserver,
       ];
     });
   const columns: Column<TestDataType>[] = [
@@ -2579,8 +2579,9 @@ it('should render action column with column manager', () => {
   });
 
   expect(container.querySelectorAll('[role="columnheader"]').length).toBe(3);
-  const actionColumn =
-    container.querySelectorAll<HTMLInputElement>('.iui-slot');
+  const actionColumn = container.querySelectorAll<HTMLInputElement>(
+    '.iui-slot',
+  );
   expect(
     actionColumn[0].firstElementChild?.className.includes(
       'iui-button iui-borderless',
@@ -2630,8 +2631,9 @@ it('should hide column when deselected in column manager', () => {
 
   const columnManager = container.querySelector('.iui-button') as HTMLElement;
   userEvent.click(columnManager);
-  const columnManagerColumns =
-    document.querySelectorAll<HTMLLIElement>('.iui-menu-item');
+  const columnManagerColumns = document.querySelectorAll<HTMLLIElement>(
+    '.iui-menu-item',
+  );
   userEvent.click(columnManagerColumns[1]);
 
   headerCells = container.querySelectorAll<HTMLDivElement>(
@@ -2675,8 +2677,9 @@ it('should be disabled in column manager if `disableToggleVisibility` is true', 
   const columnManager = container.querySelector('.iui-button') as HTMLElement;
 
   userEvent.click(columnManager);
-  const columnManagerColumns =
-    document.querySelectorAll<HTMLLIElement>('.iui-menu-item');
+  const columnManagerColumns = document.querySelectorAll<HTMLLIElement>(
+    '.iui-menu-item',
+  );
   expect(columnManagerColumns[0].classList).toContain('iui-disabled');
 
   expect(
@@ -2762,8 +2765,9 @@ it('should add expander column manually', () => {
   const rows = container.querySelectorAll('.iui-table-body .iui-row');
   expect(rows.length).toBe(3);
 
-  const expanders =
-    container.querySelectorAll<HTMLButtonElement>('.iui-row-expander');
+  const expanders = container.querySelectorAll<HTMLButtonElement>(
+    '.iui-row-expander',
+  );
   expect(expanders.length).toBe(3);
   expect(expanders[0].disabled).toBe(false);
   expect(expanders[1].disabled).toBe(true);

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -244,6 +244,22 @@ export type TableProps<
   enableColumnReordering?: boolean;
 } & Omit<CommonProps, 'title'>;
 
+// Original type for some reason is missing sub-columns
+type ColumnType<T extends Record<string, unknown> = Record<string, unknown>> =
+  Column<T> & {
+    columns: ColumnType[];
+  };
+const flattenColumns = (columns: ColumnType[]): ColumnType[] => {
+  const flatColumns: ColumnType[] = [];
+  columns.forEach((column) => {
+    flatColumns.push(column);
+    if (column.columns) {
+      flatColumns.push(...flattenColumns(column.columns));
+    }
+  });
+  return flatColumns;
+};
+
 /**
  * Table based on [react-table](https://react-table.tanstack.com/docs/api/overview).
  * @example
@@ -351,27 +367,10 @@ export const Table = <
     onRowInViewportRef.current = onRowInViewport;
   }, [onBottomReached, onRowInViewport]);
 
-  // Original type for some reason is missing sub-columns
-  type ColumnType = Column<T> & {
-    columns: ColumnType[];
-  };
-  const flattenColumns = React.useCallback(
-    (columns: ColumnType[]): ColumnType[] => {
-      const flatColumns: ColumnType[] = [];
-      columns.forEach((column) => {
-        flatColumns.push(column);
-        if (column.columns) {
-          flatColumns.push(...flattenColumns(column.columns));
-        }
-      });
-      return flatColumns;
-    },
-    [],
-  );
   const hasManualSelectionColumn = React.useMemo(() => {
     const flatColumns = flattenColumns(columns as ColumnType[]);
     return flatColumns.some((column) => column.id === SELECTION_CELL_ID);
-  }, [columns, flattenColumns]);
+  }, [columns]);
 
   const tableStateReducer = React.useCallback(
     (

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -93,7 +93,7 @@ export type TablePaginatorRendererProps = {
  * columns and data must be memoized.
  */
 export type TableProps<
-  T extends Record<string, unknown> = Record<string, unknown>,
+  T extends Record<string, unknown> = Record<string, unknown>
 > = Omit<TableOptions<T>, 'disableSortBy'> & {
   /**
    * Flag whether data is loading.
@@ -245,10 +245,11 @@ export type TableProps<
 } & Omit<CommonProps, 'title'>;
 
 // Original type for some reason is missing sub-columns
-type ColumnType<T extends Record<string, unknown> = Record<string, unknown>> =
-  Column<T> & {
-    columns: ColumnType[];
-  };
+type ColumnType<
+  T extends Record<string, unknown> = Record<string, unknown>
+> = Column<T> & {
+  columns: ColumnType[];
+};
 const flattenColumns = (columns: ColumnType[]): ColumnType[] => {
   const flatColumns: ColumnType[] = [];
   columns.forEach((column) => {
@@ -303,7 +304,7 @@ const flattenColumns = (columns: ColumnType[]): ColumnType[] => {
  * />
  */
 export const Table = <
-  T extends Record<string, unknown> = Record<string, unknown>,
+  T extends Record<string, unknown> = Record<string, unknown>
 >(
   props: TableProps<T>,
 ): JSX.Element => {
@@ -577,8 +578,9 @@ export const Table = <
       // Update column widths when table was resized
       flatHeaders.forEach((header) => {
         if (columnRefs.current[header.id]) {
-          header.resizeWidth =
-            columnRefs.current[header.id].getBoundingClientRect().width;
+          header.resizeWidth = columnRefs.current[
+            header.id
+          ].getBoundingClientRect().width;
         }
       });
 
@@ -599,8 +601,9 @@ export const Table = <
       const newColumnWidths: Record<string, number> = {};
       flatHeaders.forEach((column) => {
         if (columnRefs.current[column.id]) {
-          newColumnWidths[column.id] =
-            columnRefs.current[column.id].getBoundingClientRect().width;
+          newColumnWidths[column.id] = columnRefs.current[
+            column.id
+          ].getBoundingClientRect().width;
         }
       });
       dispatch({ type: tableResizeEndAction, columnWidths: newColumnWidths });

--- a/packages/iTwinUI-react/src/core/Table/cells/EditableCell.tsx
+++ b/packages/iTwinUI-react/src/core/Table/cells/EditableCell.tsx
@@ -5,27 +5,28 @@
 import React from 'react';
 import { CellRendererProps } from 'react-table';
 
-export type EditableCellProps<T extends Record<string, unknown>> =
-  CellRendererProps<T> & {
-    /**
-     * Callback function when cell is edited. It is called only when `onBlur` event is fired.
-     * @example
-     * const onCellEdit = React.useCallback(
-     *  (columnId: string, value: string, rowData: T) => {
-     *    setData((oldData) => {
-     *      const newData = [...oldData];
-     *      const index = oldData.indexOf(rowData);
-     *      const newObject = { ...newData[index] };
-     *      newObject[columnId] = value;
-     *      newData[index] = newObject;
-     *      return newData;
-     *    });
-     *  },
-     *  [],
-     * );
-     */
-    onCellEdit: (columnId: string, value: string, rowData: T) => void;
-  } & React.ComponentPropsWithoutRef<'div'>;
+export type EditableCellProps<
+  T extends Record<string, unknown>
+> = CellRendererProps<T> & {
+  /**
+   * Callback function when cell is edited. It is called only when `onBlur` event is fired.
+   * @example
+   * const onCellEdit = React.useCallback(
+   *  (columnId: string, value: string, rowData: T) => {
+   *    setData((oldData) => {
+   *      const newData = [...oldData];
+   *      const index = oldData.indexOf(rowData);
+   *      const newObject = { ...newData[index] };
+   *      newObject[columnId] = value;
+   *      newData[index] = newObject;
+   *      return newData;
+   *    });
+   *  },
+   *  [],
+   * );
+   */
+  onCellEdit: (columnId: string, value: string, rowData: T) => void;
+} & React.ComponentPropsWithoutRef<'div'>;
 
 /**
  * Editable cell.

--- a/packages/iTwinUI-react/src/core/Table/cells/EditableCell.tsx
+++ b/packages/iTwinUI-react/src/core/Table/cells/EditableCell.tsx
@@ -5,28 +5,27 @@
 import React from 'react';
 import { CellRendererProps } from 'react-table';
 
-export type EditableCellProps<
-  T extends Record<string, unknown>
-> = CellRendererProps<T> & {
-  /**
-   * Callback function when cell is edited. It is called only when `onBlur` event is fired.
-   * @example
-   * const onCellEdit = React.useCallback(
-   *  (columnId: string, value: string, rowData: T) => {
-   *    setData((oldData) => {
-   *      const newData = [...oldData];
-   *      const index = oldData.indexOf(rowData);
-   *      const newObject = { ...newData[index] };
-   *      newObject[columnId] = value;
-   *      newData[index] = newObject;
-   *      return newData;
-   *    });
-   *  },
-   *  [],
-   * );
-   */
-  onCellEdit: (columnId: string, value: string, rowData: T) => void;
-} & React.ComponentPropsWithoutRef<'div'>;
+export type EditableCellProps<T extends Record<string, unknown>> =
+  CellRendererProps<T> & {
+    /**
+     * Callback function when cell is edited. It is called only when `onBlur` event is fired.
+     * @example
+     * const onCellEdit = React.useCallback(
+     *  (columnId: string, value: string, rowData: T) => {
+     *    setData((oldData) => {
+     *      const newData = [...oldData];
+     *      const index = oldData.indexOf(rowData);
+     *      const newObject = { ...newData[index] };
+     *      newObject[columnId] = value;
+     *      newData[index] = newObject;
+     *      return newData;
+     *    });
+     *  },
+     *  [],
+     * );
+     */
+    onCellEdit: (columnId: string, value: string, rowData: T) => void;
+  } & React.ComponentPropsWithoutRef<'div'>;
 
 /**
  * Editable cell.
@@ -41,7 +40,15 @@ export type EditableCellProps<
 export const EditableCell = <T extends Record<string, unknown>>(
   props: EditableCellProps<T>,
 ) => {
-  const { cellElementProps, cellProps, onCellEdit, children, ...rest } = props;
+  const {
+    cellElementProps,
+    cellProps,
+    onCellEdit,
+    children,
+    isDisabled,
+    ...rest
+  } = props;
+  isDisabled; // To omit and prevent eslint error.
 
   const sanitizeString = (text: string) => {
     return text.replace(/(\r\n|\n|\r)+/gm, ' ');

--- a/packages/iTwinUI-react/stories/core/Slider.stories.tsx
+++ b/packages/iTwinUI-react/stories/core/Slider.stories.tsx
@@ -21,6 +21,11 @@ export default {
     thumbMode: 'inhibit-crossing',
     trackDisplayMode: 'auto',
   },
+  parameters: {
+    creevey: {
+      delay: 1000,
+    },
+  },
 } as Meta<SliderProps>;
 
 export const Basic: Story<SliderProps> = (args) => {

--- a/packages/iTwinUI-react/stories/core/Slider.stories.tsx
+++ b/packages/iTwinUI-react/stories/core/Slider.stories.tsx
@@ -21,11 +21,6 @@ export default {
     thumbMode: 'inhibit-crossing',
     trackDisplayMode: 'auto',
   },
-  parameters: {
-    creevey: {
-      delay: 1000,
-    },
-  },
 } as Meta<SliderProps>;
 
 export const Basic: Story<SliderProps> = (args) => {


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #647

When user doesn't pass columns with root wrapping header, then error is thrown because it can't find any columns for `hasManualSelectionColumn` check.
Also fixed an error where it would print to console that `isDisabled` is not a valid prop in `EditableCell`.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~Add component features demo in Storybook (different stories)~
- [x] ~Approve test images for new stories~
- [x] ~Add screenshots of the key elements of the component~
