### PR TITLE
chore: Fix prettier inconsistencies from duplicate versions

### DIFF
--- a/packages/iTwinUI-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/iTwinUI-react/src/core/ComboBox/ComboBox.tsx
@@ -193,8 +193,9 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
   );
 
   // Maintain internal selected value state synced with `value` prop
-  const [selectedValue, setSelectedValue] =
-    React.useState<T | undefined>(value);
+  const [selectedValue, setSelectedValue] = React.useState<T | undefined>(
+    value,
+  );
   React.useEffect(() => {
     setSelectedValue(value);
   }, [value]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11090,15 +11090,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@2.2.1:
+prettier@2.2.1, "prettier@>=2.2.1 <=2.3.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-
-"prettier@>=2.2.1 <=2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
After #613, we had two different versions of `prettier` in the lockfile. One of them was being used for IDE save and `prettier --write`, and a different one was being used for `lint-staged`. This led to random unintended formatting changes like in https://github.com/iTwin/iTwinUI-react/pull/636#discussion_r856321814 and https://github.com/iTwin/iTwinUI-react/pull/648#discussion_r863614306.

So I deduped the prettier versions in our lockfile and ran `yarn prettier` against the repo and also verified that `lint-staged` doesn't break anything on committing. The only resulting formatting change is in `ComboBox.tsx`, reverting the unintended one from #636.