### PR TITLE
fix(Table): Allow 'false' as valid filter value

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -17,7 +17,8 @@ import {
   FilterButtonBar,
   TableFilterProps,
   tableFilters
-} from './filters';import { CellProps, Column, Row } from 'react-table';
+} from './filters';
+import { CellProps, Column, Row } from 'react-table';
 import { InputGroup } from '../InputGroup';
 import { Radio } from '../Radio';
 import { SvgChevronRight } from '@itwin/itwinui-icons-react';
@@ -69,7 +70,8 @@ type TestDataType = {
   name: string;
   description: string;
   subRows?: TestDataType[];
-} & Record<string, unknown>;
+  booleanValue?: boolean;
+};
 
 const mockedData = (count = 3): TestDataType[] =>
   [...new Array(count)].map((_, index) => ({
@@ -186,6 +188,36 @@ const clearFilter = (container: HTMLElement) => {
   userEvent.click(filterIcon);
 
   screen.getByText('Clear').click();
+};
+
+const BooleanFilter = (
+  props: TableFilterProps<Record<string, unknown>>,
+): JSX.Element => {
+  const [value, setValue] = React.useState<boolean | undefined>(
+    props.column.filterValue as boolean | undefined,
+  );
+  return (
+    <BaseFilter>
+      <InputGroup displayStyle='inline'>
+        <Radio
+          name='filterOption'
+          onChange={() => setValue(true)}
+          label='True'
+          defaultChecked={value}
+        />
+        <Radio
+          name='filterOption'
+          onChange={() => setValue(false)}
+          label='False'
+          defaultChecked={value === false}
+        />
+      </InputGroup>
+      <FilterButtonBar
+        setFilter={() => props.setFilter(value)}
+        clearFilter={props.clearFilter}
+      />
+    </BaseFilter>
+  );
 };
 
 const expandAll = (container: HTMLElement, oldExpanders: Element[] = []) => {
@@ -653,36 +685,6 @@ it('should filter table', () => {
 it('should filter false values', () => {
   const onFilter = jest.fn();
 
-  const BooleanFilter = (
-    props: TableFilterProps<Record<string, unknown>>,
-  ): JSX.Element => {
-    const [value, setValue] = React.useState<boolean | undefined>(
-      props.column.filterValue as boolean | undefined,
-    );
-    return (
-      <BaseFilter>
-        <InputGroup displayStyle='inline'>
-          <Radio
-            name='filterOption'
-            onChange={() => setValue(true)}
-            label='True'
-            defaultChecked={value}
-          />
-          <Radio
-            name='filterOption'
-            onChange={() => setValue(false)}
-            label='False'
-            defaultChecked={value === false}
-          />
-        </InputGroup>
-        <FilterButtonBar
-          setFilter={() => props.setFilter(value)}
-          clearFilter={props.clearFilter}
-        />
-      </BaseFilter>
-    );
-  };
-
   const columns = [
     {
       Header: 'Header',
@@ -708,9 +710,13 @@ it('should filter false values', () => {
     { name: 'Name2', description: 'Description2', booleanValue: false },
   ] as TestDataType[];
 
-  renderComponent({ columns, onFilter, data });
+  const { container } = renderComponent({ columns, onFilter, data });
 
-  userEvent.click(screen.getByRole('button'));
+  const filterIcon = container.querySelector(
+    '.iui-filter-button .iui-button-icon',
+  ) as HTMLElement;
+
+  userEvent.click(filterIcon);
   userEvent.click(screen.getByText('False'));
   userEvent.click(screen.getByText('Filter'));
 
@@ -720,36 +726,6 @@ it('should filter false values', () => {
 
 it('should not filter undefined values', () => {
   const onFilter = jest.fn();
-
-  const BooleanFilter = (
-    props: TableFilterProps<Record<string, unknown>>,
-  ): JSX.Element => {
-    const [value, setValue] = React.useState<boolean | undefined>(
-      props.column.filterValue as boolean | undefined,
-    );
-    return (
-      <BaseFilter>
-        <InputGroup displayStyle='inline'>
-          <Radio
-            name='filterOption'
-            onChange={() => setValue(true)}
-            label='True'
-            defaultChecked={value}
-          />
-          <Radio
-            name='filterOption'
-            onChange={() => setValue(false)}
-            label='False'
-            defaultChecked={value === false}
-          />
-        </InputGroup>
-        <FilterButtonBar
-          setFilter={() => props.setFilter(value)}
-          clearFilter={props.clearFilter}
-        />
-      </BaseFilter>
-    );
-  };
 
   const columns = [
     {
@@ -777,9 +753,13 @@ it('should not filter undefined values', () => {
     { name: 'Name3', description: 'Description2' },
   ] as TestDataType[];
 
-  renderComponent({ columns, onFilter, data });
+  const { container } = renderComponent({ columns, onFilter, data });
 
-  userEvent.click(screen.getByRole('button'));
+  const filterIcon = container.querySelector(
+    '.iui-filter-button .iui-button-icon',
+  ) as HTMLElement;
+
+  userEvent.click(filterIcon);
   userEvent.click(screen.getByText('False'));
   userEvent.click(screen.getByText('Filter'));
 

--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -1,8 +1,7 @@
 /*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import {
   act,
   fireEvent,
@@ -10,24 +9,25 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { CellProps, Column, Row } from 'react-table';
-import { InputGroup } from '../InputGroup';
-import { Radio } from '../Radio';
+import { Table, TableProps } from './Table';
 import * as IntersectionHooks from '../utils/hooks/useIntersection';
-import * as UseOverflow from '../utils/hooks/useOverflow';
-import * as UseResizeObserver from '../utils/hooks/useResizeObserver';
-import { DefaultCell, EditableCell } from './cells';
-import { ActionColumn, ExpanderColumn, SelectionColumn } from './columns';
 import {
   BaseFilter,
   FilterButtonBar,
   TableFilterProps,
-  tableFilters,
+  tableFilters
 } from './filters';
-import { Table, TableProps } from './Table';
+import { CellProps, Column, Row } from 'react-table';
+import { InputGroup } from '../InputGroup';
+import { Radio } from '../Radio';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
+import { DefaultCell, EditableCell } from './cells';
 import { TablePaginator } from './TablePaginator';
+import * as UseOverflow from '../utils/hooks/useOverflow';
+import * as UseResizeObserver from '../utils/hooks/useResizeObserver';
+import userEvent from '@testing-library/user-event';
+import { ActionColumn, SelectionColumn, ExpanderColumn } from './columns';
 
 const intersectionCallbacks = new Map<Element, () => void>();
 jest

--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import {
   act,
   fireEvent,
@@ -9,25 +10,24 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { Table, TableProps } from './Table';
+import { CellProps, Column, Row } from 'react-table';
+import { InputGroup } from '../InputGroup';
+import { Radio } from '../Radio';
 import * as IntersectionHooks from '../utils/hooks/useIntersection';
+import * as UseOverflow from '../utils/hooks/useOverflow';
+import * as UseResizeObserver from '../utils/hooks/useResizeObserver';
+import { DefaultCell, EditableCell } from './cells';
+import { ActionColumn, ExpanderColumn, SelectionColumn } from './columns';
 import {
   BaseFilter,
   FilterButtonBar,
   TableFilterProps,
-  tableFilters
+  tableFilters,
 } from './filters';
-import { CellProps, Column, Row } from 'react-table';
-import { InputGroup } from '../InputGroup';
-import { Radio } from '../Radio';
-import { SvgChevronRight } from '@itwin/itwinui-icons-react';
-import { DefaultCell, EditableCell } from './cells';
+import { Table, TableProps } from './Table';
 import { TablePaginator } from './TablePaginator';
-import * as UseOverflow from '../utils/hooks/useOverflow';
-import * as UseResizeObserver from '../utils/hooks/useResizeObserver';
-import userEvent from '@testing-library/user-event';
-import { ActionColumn, SelectionColumn, ExpanderColumn } from './columns';
 
 const intersectionCallbacks = new Map<Element, () => void>();
 jest
@@ -683,8 +683,6 @@ it('should filter table', () => {
 });
 
 it('should filter false values', () => {
-  const onFilter = jest.fn();
-
   const columns = [
     {
       Header: 'Header',
@@ -710,7 +708,7 @@ it('should filter false values', () => {
     { name: 'Name2', description: 'Description2', booleanValue: false },
   ] as TestDataType[];
 
-  const { container } = renderComponent({ columns, onFilter, data });
+  const { container } = renderComponent({ columns, onFilter: jest.fn(), data });
 
   const filterIcon = container.querySelector(
     '.iui-filter-button .iui-button-icon',
@@ -725,8 +723,6 @@ it('should filter false values', () => {
 });
 
 it('should not filter undefined values', () => {
-  const onFilter = jest.fn();
-
   const columns = [
     {
       Header: 'Header',
@@ -753,7 +749,7 @@ it('should not filter undefined values', () => {
     { name: 'Name3', description: 'Description2' },
   ] as TestDataType[];
 
-  const { container } = renderComponent({ columns, onFilter, data });
+  const { container } = renderComponent({ columns, onFilter: jest.fn(), data });
 
   const filterIcon = container.querySelector(
     '.iui-filter-button .iui-button-icon',

--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import {

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -507,7 +507,7 @@ export const Table = <
     {} as Record<string, string>,
   );
 
-  const areFiltersSet = allColumns.some((column) => !!column.filterValue);
+  const areFiltersSet = allColumns.some((column) => column.filterValue !== undefined && column.filterValue !== null && column.filterValue !== '');
 
   const onRowClickHandler = React.useCallback(
     (event: React.MouseEvent, row: Row<T>) => {

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -507,7 +507,7 @@ export const Table = <
     {} as Record<string, string>,
   );
 
-  const areFiltersSet = allColumns.some((column) => column.filterValue !== undefined && column.filterValue !== null && column.filterValue !== '');
+  const areFiltersSet = allColumns.some((column) => column.filterValue != null && column.filterValue !== '');
 
   const onRowClickHandler = React.useCallback(
     (event: React.MouseEvent, row: Row<T>) => {

--- a/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.test.tsx
@@ -3,65 +3,77 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { render, screen } from '@testing-library/react';
+import { render, RenderResult, screen } from '@testing-library/react';
 import React from 'react';
-import { FilterToggle } from './FilterToggle';
+import type { HeaderGroup } from 'react-table';
+import { FilterToggle, FilterToggleProps } from './FilterToggle';
 import { tableFilters } from './tableFilters';
 
+function renderComponent<
+  T extends Record<string, unknown> = Record<string, unknown>
+>(props?: Partial<FilterToggleProps<T>>): RenderResult {
+  const defaultProps = {
+    column: {} as HeaderGroup<T>,
+    ...props,
+  };
+
+  return render(<FilterToggle {...defaultProps} />);
+}
+
 it('should display active filter', () => {
-  const column = {
+  const column = ({
     canFilter: true,
     filterValue: 'value',
     render: jest.fn(),
     setFilter: jest.fn(),
     Filter: tableFilters.TextFilter(),
-  } as any;
+  } as object) as HeaderGroup;
 
-  render(<FilterToggle column={column} />);
+  renderComponent({ column });
 
   const filterButton = screen.getByRole('button');
   expect(filterButton).toHaveClass('iui-active');
 });
 
 it('should display active filter for false filter value', () => {
-  const column = {
+  const column = ({
     canFilter: true,
     filterValue: false,
     render: jest.fn(),
     setFilter: jest.fn(),
     Filter: tableFilters.TextFilter(),
-  } as any;
+  } as object) as HeaderGroup;
 
-  render(<FilterToggle column={column} />);
+  renderComponent({ column });
 
   const filterButton = screen.getByRole('button');
   expect(filterButton).toHaveClass('iui-active');
 });
 
 it('should hide active filter when not defined', () => {
-  const column = {
+  const column = ({
     canFilter: true,
     render: jest.fn(),
     setFilter: jest.fn(),
     Filter: tableFilters.TextFilter(),
-  } as any;
+  } as object) as HeaderGroup;
 
-  render(<FilterToggle column={column} />);
+  renderComponent({ column });
 
   const filterButton = screen.getByRole('button');
   expect(filterButton).not.toHaveClass('iui-active');
 });
 
 it('should hide active filter for empty filter value', () => {
-  const column = {
+  const column = ({
     canFilter: true,
     filterValue: '',
     render: jest.fn(),
     setFilter: jest.fn(),
     Filter: tableFilters.TextFilter(),
-  } as any;
+  } as object) as HeaderGroup;
 
-  render(<FilterToggle column={column} />);
+  renderComponent({ column });
 
   const filterButton = screen.getByRole('button');
   expect(filterButton).not.toHaveClass('iui-active');

--- a/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.test.tsx
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FilterToggle } from './FilterToggle';
+import { tableFilters } from './tableFilters';
+
+it('should display active filter', () => {
+  const column = {
+    canFilter: true,
+    filterValue: 'value',
+    render: jest.fn(),
+    setFilter: jest.fn(),
+    Filter: tableFilters.TextFilter(),
+  } as any;
+
+  render(<FilterToggle column={column} />);
+
+  const filterButton = screen.getByRole('button');
+  expect(filterButton).toHaveClass('iui-active');
+});
+
+it('should display active filter for false filter value', () => {
+  const column = {
+    canFilter: true,
+    filterValue: false,
+    render: jest.fn(),
+    setFilter: jest.fn(),
+    Filter: tableFilters.TextFilter(),
+  } as any;
+
+  render(<FilterToggle column={column} />);
+
+  const filterButton = screen.getByRole('button');
+  expect(filterButton).toHaveClass('iui-active');
+});
+
+it('should hide active filter when not defined', () => {
+  const column = {
+    canFilter: true,
+    render: jest.fn(),
+    setFilter: jest.fn(),
+    Filter: tableFilters.TextFilter(),
+  } as any;
+
+  render(<FilterToggle column={column} />);
+
+  const filterButton = screen.getByRole('button');
+  expect(filterButton).not.toHaveClass('iui-active');
+});
+
+it('should hide active filter for empty filter value', () => {
+  const column = {
+    canFilter: true,
+    filterValue: '',
+    render: jest.fn(),
+    setFilter: jest.fn(),
+    Filter: tableFilters.TextFilter(),
+  } as any;
+
+  render(<FilterToggle column={column} />);
+
+  const filterButton = screen.getByRole('button');
+  expect(filterButton).not.toHaveClass('iui-active');
+});

--- a/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
@@ -42,7 +42,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
     close();
   }, [close, column]);
 
-  const columnFiltered = column.filterValue !== undefined && column.filterValue !== null && column.filterValue !== '';
+  const isColumnFiltered = column.filterValue != null && column.filterValue !== '';
 
   return (
     <>
@@ -56,7 +56,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
         >
           <IconButton
             styleType='borderless'
-            isActive={isVisible || columnFiltered}
+            isActive={isVisible || isColumnFiltered}
             className={cx('iui-filter-button', className)}
             onClick={(e) => {
               setIsVisible((v) => !v);
@@ -65,7 +65,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
             }}
             {...rest}
           >
-            {columnFiltered ? <SvgFilter /> : <SvgFilterHollow />}
+            {isColumnFiltered ? <SvgFilter /> : <SvgFilterHollow />}
           </IconButton>
         </Popover>
       )}

--- a/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
@@ -42,6 +42,8 @@ export const FilterToggle = <T extends Record<string, unknown>>(
     close();
   }, [close, column]);
 
+  const columnFiltered = column.filterValue !== undefined && column.filterValue !== null && column.filterValue !== '';
+
   return (
     <>
       {column.canFilter && column.Filter && (
@@ -54,7 +56,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
         >
           <IconButton
             styleType='borderless'
-            isActive={isVisible || column.filterValue}
+            isActive={isVisible || columnFiltered}
             className={cx('iui-filter-button', className)}
             onClick={(e) => {
               setIsVisible((v) => !v);
@@ -63,7 +65,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
             }}
             {...rest}
           >
-            {column.filterValue ? <SvgFilter /> : <SvgFilterHollow />}
+            {columnFiltered ? <SvgFilter /> : <SvgFilterHollow />}
           </IconButton>
         </Popover>
       )}


### PR DESCRIPTION
Addresses issue raised in #658. `false` values were being ignored by the filter. These changes allow the filter to be considered off when the filter value on the column is `undefined`, `null`, or `''`, but on when it is `false`, as there are valid use cases to filter for a boolean.