### PR TITLE
fix(toaster): Do not call `ReactDOM` render multiple times

### DIFF
--- a/packages/iTwinUI-react/src/core/SkipToContentLink/SkipToContentLink.test.tsx
+++ b/packages/iTwinUI-react/src/core/SkipToContentLink/SkipToContentLink.test.tsx
@@ -43,7 +43,6 @@ it('should propagate misc props in link', () => {
   const link = container.querySelector(
     '.iui-skip-to-content-link',
   ) as HTMLElement;
-  console.log(link);
   expect(link).toHaveAttribute('href', '#main-content-id');
   expect(link).toHaveClass('test-class');
   expect(link).toHaveStyle('color: red');

--- a/packages/iTwinUI-react/src/core/Toast/ToastWrapper.test.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/ToastWrapper.test.tsx
@@ -3,11 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import { ToastWrapper, ToastWrapperHandle } from './ToastWrapper';
 import { ToastProps } from './Toast';
-import { act } from 'react-dom/test-utils';
 
 const mockToastObject1 = {
   category: 'informational',

--- a/packages/iTwinUI-react/src/core/Toast/ToastWrapper.test.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/ToastWrapper.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
   ref = React.createRef<ToastWrapperHandle>();
 });
 
-it.only('should render toasts', () => {
+it('should render toasts', () => {
   const { container } = render(<ToastWrapper ref={ref} />);
   expect(container.querySelector('.iui-toast-wrapper')).toBeTruthy();
 

--- a/packages/iTwinUI-react/src/core/Toast/ToastWrapper.test.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/ToastWrapper.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import { ToastWrapper } from './ToastWrapper';
+import { ToastWrapper, ToastWrapperHandle } from './ToastWrapper';
 import { ToastProps } from './Toast';
 import { act } from 'react-dom/test-utils';
 
@@ -24,12 +24,19 @@ const mockToastObject2 = {
   isVisible: true,
 } as ToastProps;
 
-it('should render toasts', () => {
-  const { container } = render(
-    <ToastWrapper toasts={[mockToastObject1, mockToastObject2]} />,
-  );
+let ref: React.RefObject<ToastWrapperHandle>;
 
+beforeEach(() => {
+  ref = React.createRef<ToastWrapperHandle>();
+});
+
+it.only('should render toasts', () => {
+  const { container } = render(<ToastWrapper ref={ref} />);
   expect(container.querySelector('.iui-toast-wrapper')).toBeTruthy();
+
+  act(() => {
+    ref.current?.setToasts([mockToastObject1, mockToastObject2]);
+  });
 
   const toasts = container.querySelectorAll('.iui-toast');
   expect(toasts.length).toBe(2);
@@ -41,9 +48,10 @@ it('should render toasts', () => {
 
 it('should remove toast with close icon click', () => {
   jest.useFakeTimers();
-  const { container } = render(
-    <ToastWrapper toasts={[mockToastObject1, mockToastObject2]} />,
-  );
+  const { container } = render(<ToastWrapper ref={ref} />);
+  act(() => {
+    ref.current?.setToasts([mockToastObject1, mockToastObject2]);
+  });
 
   expect(container.querySelector('.iui-toast-wrapper')).toBeTruthy();
 
@@ -63,17 +71,18 @@ it('should remove toast with close icon click', () => {
 
 it('should remove all toasts', () => {
   jest.useFakeTimers();
-  const { container, rerender } = render(
-    <ToastWrapper toasts={[mockToastObject1, mockToastObject2]} />,
-  );
-
+  const { container } = render(<ToastWrapper ref={ref} />);
+  act(() => {
+    ref.current?.setToasts([mockToastObject1, mockToastObject2]);
+  });
   expect(container.querySelector('.iui-toast-wrapper')).toBeTruthy();
 
   let toasts = container.querySelectorAll('.iui-toast');
   expect(toasts.length).toBe(2);
   act(() => {
-    rerender(<ToastWrapper toasts={[]} />);
+    ref.current?.setToasts([]);
   });
+
   jest.advanceTimersByTime(400);
   toasts = container.querySelectorAll('.iui-toast');
   expect(toasts.length).toBe(0);
@@ -88,12 +97,12 @@ it.each([
   'bottom',
   'bottom-end',
 ] as const)('should change placement to %s', (placement) => {
-  const { container } = render(
-    <ToastWrapper
-      toasts={[mockToastObject1, mockToastObject2]}
-      placement={placement}
-    />,
-  );
+  const { container } = render(<ToastWrapper ref={ref} />);
+
+  act(() => {
+    ref.current?.setToasts([mockToastObject1, mockToastObject2]);
+    ref.current?.setPlacement(placement);
+  });
 
   expect(container.querySelector('.iui-toast-wrapper')).toBeTruthy();
   expect(

--- a/packages/iTwinUI-react/src/core/Toast/ToastWrapper.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/ToastWrapper.tsx
@@ -23,12 +23,8 @@ export const ToastWrapper = React.forwardRef<ToastWrapperHandle>((_, ref) => {
   React.useImperativeHandle(
     ref,
     () => ({
-      setToasts: (t) => {
-        setToasts(t);
-      },
-      setPlacement: (p) => {
-        setPlacement(p);
-      },
+      setToasts,
+      setPlacement,
     }),
     [],
   );

--- a/packages/iTwinUI-react/src/core/Toast/ToastWrapper.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/ToastWrapper.tsx
@@ -8,13 +8,30 @@ import cx from 'classnames';
 import Toast, { ToastProps } from './Toast';
 import { ToasterSettings } from './Toaster';
 
-type ToastWrapperProps = {
-  toasts: ToastProps[];
-} & Pick<ToasterSettings, 'placement'>;
+type ToastPlacement = NonNullable<ToasterSettings['placement']>;
 
-export const ToastWrapper = (props: ToastWrapperProps) => {
-  const { toasts, placement = 'top' } = props;
+export type ToastWrapperHandle = {
+  setToasts: (toasts: ToastProps[]) => void;
+  setPlacement: (placement: ToastPlacement) => void;
+};
+
+export const ToastWrapper = React.forwardRef<ToastWrapperHandle>((_, ref) => {
+  const [toasts, setToasts] = React.useState<ToastProps[]>([]);
+  const [placement, setPlacement] = React.useState<ToastPlacement>('top');
   const placementPosition = placement.startsWith('top') ? 'top' : 'bottom';
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      setToasts: (t) => {
+        setToasts(t);
+      },
+      setPlacement: (p) => {
+        setPlacement(p);
+      },
+    }),
+    [],
+  );
 
   return (
     <span className={cx(`iui-toast-wrapper`, `iui-placement-${placement}`)}>
@@ -29,4 +46,4 @@ export const ToastWrapper = (props: ToastWrapperProps) => {
       })}
     </span>
   );
-};
+});

--- a/packages/iTwinUI-react/src/core/Toast/Toaster.test.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/Toaster.test.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { act } from 'react-dom/test-utils';
 import toaster from '.';
 import { ToastCategory, ToastProps } from './Toast';
 import { ToastOptions } from './Toaster';
@@ -63,34 +64,48 @@ afterEach(() => {
 });
 
 it('should add toast with success', () => {
-  toaster.positive('mockContent', mockedOptions());
+  act(() => {
+    toaster.positive('mockContent', mockedOptions());
+  });
   expect(toaster['toasts'].length).toBe(1);
   assertAddedToast(toaster['toasts'][0], 'positive', 'mockContent', 1);
 });
 
 it('should add toast with negative', () => {
-  toaster.negative('mockContent', mockedOptions());
+  act(() => {
+    toaster.negative('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][0], 'negative', 'mockContent', 1);
 });
 
 it('should add toast with informational', () => {
-  toaster.informational('mockContent', mockedOptions());
+  act(() => {
+    toaster.informational('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][0], 'informational', 'mockContent', 1);
 });
 
 it('should add toast with warning', () => {
-  toaster.warning('mockContent', mockedOptions());
+  act(() => {
+    toaster.warning('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][0], 'warning', 'mockContent', 1);
 });
 
 it('should add toasts and remove all', () => {
-  toaster.informational('mockContent', mockedOptions());
+  act(() => {
+    toaster.informational('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][0], 'informational', 'mockContent', 1);
 
-  toaster.positive('mockContent', mockedOptions());
+  act(() => {
+    toaster.positive('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][0], 'positive', 'mockContent', 2);
 
-  toaster.closeAll();
+  act(() => {
+    toaster.closeAll();
+  });
   assertRemovedToast(toaster['toasts'][1], 'informational', 'mockContent', 1);
   assertRemovedToast(toaster['toasts'][0], 'positive', 'mockContent', 2);
 
@@ -100,9 +115,12 @@ it('should add toasts and remove all', () => {
 });
 
 it('should add toast and remove using return function', () => {
-  const { close } = toaster.informational('mockContent', {
-    ...mockedOptions(),
-    type: 'persisting',
+  let close: () => void = () => {};
+  act(() => {
+    ({ close } = toaster.informational('mockContent', {
+      ...mockedOptions(),
+      type: 'persisting',
+    }));
   });
   assertAddedToast(
     toaster['toasts'][0],
@@ -116,7 +134,9 @@ it('should add toast and remove using return function', () => {
     },
   );
 
-  close();
+  act(() => {
+    close();
+  });
   assertRemovedToast(
     toaster['toasts'][0],
     'informational',
@@ -135,11 +155,15 @@ it('should add toast and remove using return function', () => {
 });
 
 it('should change order to bottom to top', () => {
-  toaster.setSettings({ placement: 'top', order: 'ascending' });
-  toaster.informational('mockContent', mockedOptions());
+  act(() => {
+    toaster.setSettings({ placement: 'top', order: 'ascending' });
+    toaster.informational('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][0], 'informational', 'mockContent', 1);
 
-  toaster.positive('mockContent', mockedOptions());
+  act(() => {
+    toaster.positive('mockContent', mockedOptions());
+  });
   assertAddedToast(toaster['toasts'][1], 'positive', 'mockContent', 2);
 });
 
@@ -151,10 +175,12 @@ it.each([
   'bottom',
   'bottom-end',
 ] as const)('should change placement to %s', (placement) => {
-  toaster.setSettings({
-    placement: placement,
+  act(() => {
+    toaster.setSettings({
+      placement: placement,
+    });
+    toaster.informational('mockContent', mockedOptions());
   });
-  toaster.informational('mockContent', mockedOptions());
   expect(document.querySelector('.iui-toast-wrapper')).toHaveClass(
     `iui-placement-${placement}`,
   );

--- a/packages/iTwinUI-react/src/core/Toast/Toaster.test.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/Toaster.test.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import toaster from '.';
 import { ToastCategory, ToastProps } from './Toast';
 import { ToastOptions } from './Toaster';

--- a/packages/iTwinUI-react/src/core/Toast/Toaster.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/Toaster.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { getContainer } from '../utils';
 import { ToastCategory, ToastProps } from './Toast';
-import { ToastWrapper } from './ToastWrapper';
+import { ToastWrapper, ToastWrapperHandle } from './ToastWrapper';
 
 const TOASTS_CONTAINER_ID = 'iui-toasts-container';
 
@@ -44,6 +44,16 @@ export default class Toaster {
     order: 'descending',
     placement: 'top',
   };
+  private toastsRef = React.createRef<ToastWrapperHandle>();
+
+  constructor() {
+    const container = getContainer(TOASTS_CONTAINER_ID);
+    if (!container) {
+      return;
+    }
+
+    ReactDOM.render(<ToastWrapper ref={this.toastsRef} />, container);
+  }
 
   /**
    * Set global Toaster settings for toasts order and placement.
@@ -55,6 +65,7 @@ export default class Toaster {
       ? 'ascending'
       : 'descending';
     this.settings = newSettings;
+    this.toastsRef?.current?.setPlacement(this.settings.placement ?? 'top');
   }
 
   public positive(content: React.ReactNode, options?: ToastOptions) {
@@ -105,15 +116,7 @@ export default class Toaster {
   }
 
   private updateView() {
-    const container = getContainer(TOASTS_CONTAINER_ID);
-    if (!container) {
-      return;
-    }
-
-    ReactDOM.render(
-      <ToastWrapper toasts={this.toasts} placement={this.settings.placement} />,
-      container,
-    );
+    this.toastsRef.current?.setToasts(this.toasts);
   }
 
   private closeToast(toastId: number): void {

--- a/packages/iTwinUI-react/src/core/Toast/Toaster.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/Toaster.tsx
@@ -65,7 +65,7 @@ export default class Toaster {
       ? 'ascending'
       : 'descending';
     this.settings = newSettings;
-    this.toastsRef?.current?.setPlacement(this.settings.placement ?? 'top');
+    this.toastsRef.current?.setPlacement(this.settings.placement ?? 'top');
   }
 
   public positive(content: React.ReactNode, options?: ToastOptions) {

--- a/packages/iTwinUI-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/iTwinUI-react/src/core/Tooltip/Tooltip.test.tsx
@@ -2,9 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import { Tooltip } from './Tooltip';
 


### PR DESCRIPTION
I have changed approach a little in toaster not to call `render` multiple times (as this is not the recommended way to do ).
I changed that mostly because of my v18 work, where tests with new root render were not passing for some reason.
With this change toasts will use react change detection and rerender as state of the component will change.
Using fancy [useImperativeHandle](https://reactjs.org/docs/hooks-reference.html#useimperativehandle) hook.