### PR TITLE
chore: Move gitattributes to root

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 * text=auto eol=lf
-diff --git a/packages/iTwinUI-react/.gitattributes b/packages/iTwinUI-react/.gitattributes

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+diff --git a/packages/iTwinUI-react/.gitattributes b/packages/iTwinUI-react/.gitattributes

--- a/packages/iTwinUI-react/.gitattributes
+++ b/packages/iTwinUI-react/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf


### PR DESCRIPTION
This was leftover/missing from the monorepo PR.
