### PR TITLE
chore: Update icons packages version

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
-    "@itwin/itwinui-icons-react": "^1.9.0",
+    "@itwin/itwinui-icons-react": "^1.10.1",
     "@itwin/itwinui-react": "*",
     "@storybook/addon-a11y": "~6.5.3",
     "@storybook/addon-actions": "~6.5.3",

--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@itwin/itwinui-css": "^0.58.0",
-    "@itwin/itwinui-icons-react": "^1.5.0",
-    "@itwin/itwinui-illustrations-react": "^1.0.1",
+    "@itwin/itwinui-icons-react": "^1.10.1",
+    "@itwin/itwinui-illustrations-react": "^1.3.1",
     "@tippyjs/react": "^4.2.5",
     "@types/react-table": "^7.0.18",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,15 +1271,15 @@
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-0.58.0.tgz#e385efc7ce903fc56e955976271e366fa3c0265c"
   integrity sha512-BBMoB8OuMR8v5ndBgZlWDSEgIuJzOh5ja3WxH3w2uaT3VWnFMS00DURhYnfNnBOqnWbGWz7v8eX56GuZfIhUbQ==
 
-"@itwin/itwinui-icons-react@^1.5.0", "@itwin/itwinui-icons-react@^1.9.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.10.0.tgz#b86546885dbd4e621fb4506af0d7ab9a2bab01a7"
-  integrity sha512-s0jsPNrULDlbQiGr+sIWTiyseJjuo9zOZN7cKyohVzfS6i5YHt2xQln5g5O8JL52VhLmutgKyOEty0K78cbvLQ==
+"@itwin/itwinui-icons-react@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.10.1.tgz#fb6517089ba964a57cc3fec37a63af3ccd4768e0"
+  integrity sha512-kBxDI1TuKiVtHhGmRVX5oOz1dszKvNUcYcDYOd2RzKVbHA8nMfx6dq3E8n4j2FeYGgxM9/wYpe/4wE0ykS8NuA==
 
-"@itwin/itwinui-illustrations-react@^1.0.1":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-1.3.0.tgz#e40407e25e5c5e1291beeb656842bb7c8cfd1254"
-  integrity sha512-80H4sS1PRCs8U5VgzO6F8sWvhkxPS5K3Bu5o99A+M3/aBjuk3zhLn+fN49lBkmFJ+sHWA6xE7+T3cF7xPkz8qA==
+"@itwin/itwinui-illustrations-react@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-illustrations-react/-/itwinui-illustrations-react-1.3.1.tgz#f534fa1da707272a4351f3b2bbc240c9ea8e3ae6"
+  integrity sha512-hIZwYwd1qmyjt5yiL8Lg6E3CpgeLxGOnb4dVktoM+h3h5zSmgjhm2qFk+RqgsqV+dy0Fb2cs1jH4Jup9jWY9pA==
 
 "@jest/console@^28.1.0":
   version "28.1.0"


### PR DESCRIPTION
As I updated to react 18, icons also needed to have `peerDeps` updated.
Latest versions have that.