### PR TITLE
fix(Table): Overriding min-width for the whole table

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -711,7 +711,10 @@ export const Table = <
             { [`iui-${density}`]: density !== 'default' },
             className,
           ),
-          style,
+          style: {
+            minWidth: 0, // Overrides the min-width set by the react-table but when we support horizontal scroll it is not needed
+            ...style,
+          },
         })}
         {...ariaDataAttributes}
       >


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #643 <!-- Add issue number -->

When there is no column with `width` or `minWIdth` set, table `minWidth` is `0px` but when there are some columns that have `width` or `minWidth` then react-table sums them up and sets as table `minWidth` but that sometimes prevents horizontal scroll from working properly.

## Checklist

- [x] ~Add meaningful unit tests for your component (verify that all lines are covered)~
- [x] Verify that all existing tests pass
- [x] ~Add component features demo in Storybook (different stories)~
- [x] ~Approve test images for new stories~
- [x] ~Add screenshots of the key elements of the component~
