### PR TITLE
fix(Table): Prevents crashing when clearing editable cell

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -1775,6 +1775,12 @@ it('should edit cell data', async () => {
   });
   fireEvent.blur(editableCells[1]);
   expect(onCellEdit).toHaveBeenCalledWith('name', 'test data', mockedData()[1]);
+
+  fireEvent.input(editableCells[2], {
+    target: { innerText: '' },
+  });
+  fireEvent.blur(editableCells[2]);
+  expect(onCellEdit).toHaveBeenCalledWith('name', '', mockedData()[2]);
 });
 
 it('should handle unwanted actions on editable cell', async () => {

--- a/packages/iTwinUI-react/src/core/Table/cells/EditableCell.tsx
+++ b/packages/iTwinUI-react/src/core/Table/cells/EditableCell.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import { CellRendererProps } from 'react-table';
+import { getRandomValue } from '../../utils';
 
 export type EditableCellProps<
   T extends Record<string, unknown>
@@ -62,6 +63,8 @@ export const EditableCell = <T extends Record<string, unknown>>(
     setValue(sanitizeString(cellProps.value));
   }, [cellProps.value]);
 
+  const [key, setKey] = React.useState(getRandomValue(10));
+
   const [isDirty, setIsDirty] = React.useState(false);
 
   return (
@@ -69,6 +72,7 @@ export const EditableCell = <T extends Record<string, unknown>>(
       {...cellElementProps}
       contentEditable
       suppressContentEditableWarning
+      key={key}
       {...rest}
       onInput={(e) => {
         setValue(sanitizeString((e.target as HTMLElement).innerText));
@@ -80,6 +84,9 @@ export const EditableCell = <T extends Record<string, unknown>>(
           onCellEdit(cellProps.column.id, value, cellProps.row.original);
         }
         props.onBlur?.(e);
+        // Prevents error when text is cleared.
+        // New key makes React to reattach with the DOM so it won't complain about deleted text node.
+        setKey(getRandomValue(10));
       }}
       onKeyDown={(e) => {
         // Prevents from adding HTML elements (div, br) inside a cell on Enter press


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #703  <!-- Add issue number -->

Error was throw because when clearing editable cell, text node is being removed and React doesn't like DOM manipulation outside React. So giving editable cell a new key will make React reattach with the cell element in the DOM and it won't complain.

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- [x] ~Add component features demo in Storybook (different stories)~
- [x] ~Approve test images for new stories~
- [x] ~Add screenshots of the key elements of the component~
