### PR TITLE
feat(Table): itwinui-css 1.0.0 Class Refactor

### DIFF
--- a/apps/storybook/src/Table.test.ts
+++ b/apps/storybook/src/Table.test.ts
@@ -42,12 +42,12 @@ describe('Table', () => {
           break;
         }
         case 'Customized Columns': {
-          cy.get('.iui-row-expander').last().click();
+          cy.get('.iui-table-row-expander').last().click();
           break;
         }
         case 'Expandable':
         case 'Expandable Subrows': {
-          cy.get('.iui-row-expander').first().click();
+          cy.get('.iui-table-row-expander').first().click();
           break;
         }
         case 'Editable': {
@@ -55,7 +55,7 @@ describe('Table', () => {
           break;
         }
         case 'Filters': {
-          cy.get('.iui-filter-button').first().click({ force: true }); // force because the button is hidden
+          cy.get('.iui-table-filter-button').first().click({ force: true }); // force because the button is hidden
           break;
         }
       }

--- a/packages/iTwinUI-react/src/core/Table/SubRowExpander.tsx
+++ b/packages/iTwinUI-react/src/core/Table/SubRowExpander.tsx
@@ -26,7 +26,7 @@ export const SubRowExpander = <T extends Record<string, unknown>>(
       ) : (
         <IconButton
           style={{ marginRight: 8 }}
-          className='iui-row-expander'
+          className='iui-table-row-expander'
           styleType='borderless'
           size='small'
           onClick={(e) => {

--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -154,7 +154,7 @@ async function assertRowsData(rows: NodeListOf<Element>, data = mockedData()) {
   for (let i = 0; i < rows.length; i++) {
     const row = rows.item(i);
     const { name, description } = data[i];
-    const cells = row.querySelectorAll('.iui-cell');
+    const cells = row.querySelectorAll('.iui-table-cell');
     expect(cells.length).toBe(3);
     expect(cells[0].textContent).toEqual(name);
     expect(cells[1].textContent).toEqual(description);
@@ -165,13 +165,13 @@ async function assertRowsData(rows: NodeListOf<Element>, data = mockedData()) {
 
 const setFilter = async (container: HTMLElement, value: string) => {
   const filterIcon = container.querySelector(
-    '.iui-filter-button .iui-button-icon',
+    '.iui-table-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
   await userEvent.click(filterIcon);
 
   const filterInput = document.querySelector(
-    '.iui-column-filter input',
+    '.iui-table-column-filter input',
   ) as HTMLInputElement;
   expect(filterInput).toBeVisible();
 
@@ -183,7 +183,7 @@ const setFilter = async (container: HTMLElement, value: string) => {
 
 const clearFilter = async (container: HTMLElement) => {
   const filterIcon = container.querySelector(
-    '.iui-filter-button .iui-button-icon',
+    '.iui-table-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
   await userEvent.click(filterIcon);
@@ -226,7 +226,7 @@ const expandAll = async (
   oldExpanders: Element[] = [],
 ) => {
   const allExpanders = Array.from(
-    container.querySelectorAll('.iui-row-expander'),
+    container.querySelectorAll('.iui-table-row-expander'),
   );
   const newExpanders = allExpanders.filter((e) => !oldExpanders.includes(e));
   for (const button of newExpanders) {
@@ -246,7 +246,7 @@ it('should render table with data', async () => {
   const { container } = renderComponent(undefined, onViewClick);
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows);
   expect(onViewClick).toHaveBeenCalledTimes(3);
 });
@@ -257,7 +257,7 @@ it('should show spinner when loading', () => {
   expect(
     container.querySelector('.iui-progress-indicator-radial'),
   ).toBeTruthy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(0);
 });
 
@@ -265,7 +265,7 @@ it('should show empty message when there is no data', () => {
   const { container } = renderComponent({ data: [] });
 
   screen.getByText('Empty table');
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(0);
 });
 
@@ -302,7 +302,7 @@ it('should render column with custom className', () => {
   });
 
   const column = container.querySelector(
-    '.iui-table-header .iui-cell.test-className',
+    '.iui-table-header .iui-table-cell.test-className',
   );
   expect(column).toBeTruthy();
 });
@@ -325,7 +325,7 @@ it('should render cell with custom className', () => {
   });
 
   const cell = container.querySelector(
-    '.iui-table-body .iui-cell.test-className',
+    '.iui-table-body .iui-table-cell.test-className',
   );
   expect(cell).toBeTruthy();
 });
@@ -335,7 +335,7 @@ it('should handle checkbox clicks', async () => {
   const { container } = renderComponent({ isSelectable: true, onSelect });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   expect(onSelect).not.toHaveBeenCalled();
@@ -362,25 +362,25 @@ it('should handle row clicks', async () => {
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await userEvent.click(getByText(mockedData()[1].name));
-  expect(rows[1].classList).toContain('iui-selected');
+  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
   expect(onSelect).toHaveBeenCalledTimes(1);
   expect(onRowClick).toHaveBeenCalledTimes(1);
 
   await userEvent.click(getByText(mockedData()[2].name));
-  expect(rows[1].classList).not.toContain('iui-selected');
-  expect(rows[2].classList).toContain('iui-selected');
+  expect(rows[1]).not.toHaveAttribute('aria-selected', 'true');
+  expect(rows[2]).toHaveAttribute('aria-selected', 'true');
   expect(onSelect).toHaveBeenCalledTimes(2);
   expect(onRowClick).toHaveBeenCalledTimes(2);
 
   const user = userEvent.setup();
   await user.keyboard('[ControlLeft>]'); // Press Control (without releasing it)
   await user.click(getByText(mockedData()[1].name)); // Perform a click with `ctrlKey: true`
-  expect(rows[1].classList).toContain('iui-selected');
-  expect(rows[2].classList).toContain('iui-selected');
+  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
+  expect(rows[2]).toHaveAttribute('aria-selected', 'true');
   expect(onSelect).toHaveBeenCalledTimes(3);
   expect(onRowClick).toHaveBeenCalledTimes(3);
 });
@@ -396,7 +396,7 @@ it('should not select when clicked on row but selectRowOnClick flag is false', a
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await userEvent.click(getByText(mockedData()[1].name));
@@ -443,7 +443,7 @@ it('should not trigger onSelect when sorting and filtering', async () => {
   });
 
   const nameHeader = container.querySelector(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   ) as HTMLDivElement;
   expect(nameHeader).toBeTruthy();
   expect(nameHeader.classList).not.toContain('iui-sorted');
@@ -462,7 +462,9 @@ it('should not show sorting icon if sorting is disabled', () => {
     isSortable: false,
   });
 
-  expect(container.querySelector('.iui-cell-end-icon .iui-sort')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-cell-end-icon .iui-table-sort'),
+  ).toBeFalsy();
 });
 
 it('should not show sort icon if data is loading', () => {
@@ -472,7 +474,9 @@ it('should not show sort icon if data is loading', () => {
     isLoading: true,
   });
 
-  expect(container.querySelector('.iui-cell-end-icon .iui-sort')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-cell-end-icon .iui-table-sort'),
+  ).toBeFalsy();
 });
 
 it('should show sort icon if more data is loading', () => {
@@ -481,7 +485,9 @@ it('should show sort icon if more data is loading', () => {
     isLoading: true,
   });
 
-  expect(container.querySelector('.iui-cell-end-icon .iui-sort')).toBeTruthy();
+  expect(
+    container.querySelector('.iui-table-cell-end-icon .iui-table-sort'),
+  ).toBeTruthy();
 });
 
 it('should not show sort icon if data is empty', () => {
@@ -490,7 +496,9 @@ it('should not show sort icon if data is empty', () => {
     data: [],
   });
 
-  expect(container.querySelector('.iui-cell-end-icon .iui-sort')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-cell-end-icon .iui-table-sort'),
+  ).toBeFalsy();
 });
 
 it('should sort name column correctly', async () => {
@@ -508,22 +516,22 @@ it('should sort name column correctly', async () => {
   });
 
   const nameHeader = container.querySelector(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   ) as HTMLDivElement;
   expect(nameHeader).toBeTruthy();
   expect(nameHeader.classList).not.toContain('iui-sorted');
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
 
   await assertRowsData(rows, mocked);
 
   const sortIcon = container.querySelector(
-    '.iui-cell-end-icon .iui-sort',
+    '.iui-table-cell-end-icon .iui-table-sort',
   ) as HTMLDivElement;
   expect(sortIcon).toBeTruthy();
 
   //first click
   await userEvent.click(nameHeader);
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(nameHeader.classList).toContain('iui-sorted');
   await assertRowsData(rows, sortedByName);
   expect(onSort).toHaveBeenCalledWith(
@@ -539,7 +547,7 @@ it('should sort name column correctly', async () => {
 
   //second click
   await userEvent.click(nameHeader);
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(nameHeader.classList).toContain('iui-sorted');
   await assertRowsData(rows, [...sortedByName].reverse());
   expect(onSort).toHaveBeenCalledWith(
@@ -555,7 +563,7 @@ it('should sort name column correctly', async () => {
 
   //third click resets it
   await userEvent.click(nameHeader);
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(nameHeader.classList).not.toContain('iui-sorted');
   await assertRowsData(rows, mocked);
   expect(onSort).toHaveBeenCalledWith(
@@ -584,7 +592,9 @@ it('should not show sort icon if disabled in column level', () => {
     isSortable: true,
   });
 
-  expect(container.querySelector('.iui-sort .iui-icon-wrapper')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-sort .iui-icon-wrapper'),
+  ).toBeFalsy();
 });
 
 it('should trigger onBottomReached', () => {
@@ -594,7 +604,7 @@ it('should trigger onBottomReached', () => {
     onBottomReached,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(50);
 
   expect(onBottomReached).not.toHaveBeenCalled();
@@ -626,11 +636,11 @@ it('should trigger onBottomReached with filter applied', async () => {
     onBottomReached,
   });
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(50);
 
   await setFilter(container, '1');
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(14);
 
   expect(onBottomReached).not.toHaveBeenCalled();
@@ -646,7 +656,7 @@ it('should trigger onRowInViewport', () => {
     onRowInViewport,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(50);
 
   expect(onRowInViewport).not.toHaveBeenCalled();
@@ -677,12 +687,12 @@ it('should filter table', async () => {
   const { container } = renderComponent({ columns: mockedColumns, onFilter });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await setFilter(container, '2');
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(1);
   expect(onFilter).toHaveBeenCalledWith(
     [{ fieldType: 'text', filterType: 'text', id: 'name', value: '2' }],
@@ -719,7 +729,7 @@ it('should filter false values', async () => {
   const { container } = renderComponent({ columns, onFilter: jest.fn(), data });
 
   const filterIcon = container.querySelector(
-    '.iui-filter-button .iui-button-icon',
+    '.iui-table-filter-button .iui-button-icon',
   ) as HTMLElement;
 
   await userEvent.click(filterIcon);
@@ -760,7 +770,7 @@ it('should not filter undefined values', async () => {
   const { container } = renderComponent({ columns, onFilter: jest.fn(), data });
 
   const filterIcon = container.querySelector(
-    '.iui-filter-button .iui-button-icon',
+    '.iui-table-filter-button .iui-button-icon',
   ) as HTMLElement;
 
   await userEvent.click(filterIcon);
@@ -795,17 +805,17 @@ it('should clear filter', async () => {
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(1);
 
   const filterIcon = container.querySelector(
-    '.iui-filter-button .iui-button-icon',
+    '.iui-table-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
   await userEvent.click(filterIcon);
 
   const filterInput = document.querySelector(
-    '.iui-column-filter input',
+    '.iui-table-column-filter input',
   ) as HTMLInputElement;
   expect(filterInput).toBeTruthy();
   expect(filterInput).toBeVisible();
@@ -814,7 +824,7 @@ it('should clear filter', async () => {
   await userEvent.click(screen.getByText('Clear'));
   expect(filterInput).not.toBeVisible();
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
   expect(onFilter).toHaveBeenCalledWith(
     [],
@@ -845,12 +855,12 @@ it('should not filter table when manualFilters flag is on', async () => {
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await setFilter(container, '2');
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
   expect(onFilter).toHaveBeenCalledWith(
     [{ fieldType: 'text', filterType: 'text', id: 'name', value: '2' }],
@@ -876,11 +886,11 @@ it('should not show filter icon when filter component is not set', () => {
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   const filterIcon = container.querySelector(
-    '.iui-filter-button .iui-button-icon',
+    '.iui-table-filter-button .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeFalsy();
 });
@@ -907,7 +917,7 @@ it('should show active filter icon when more data is loading', async () => {
   await setFilter(container, '2');
 
   const filterIcon = container.querySelector(
-    '.iui-filter-button.iui-active .iui-button-icon',
+    '.iui-table-filter-button.iui-active .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
 });
@@ -930,16 +940,16 @@ it('should show message and active filter icon when there is no data after filte
   const { container } = renderComponent({ columns: mockedColumns });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await setFilter(container, 'invalid value');
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(0);
   screen.getByText('No results. Clear filter.');
   const filterIcon = container.querySelector(
-    '.iui-filter-button.iui-active .iui-button-icon',
+    '.iui-table-filter-button.iui-active .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
 });
@@ -970,7 +980,7 @@ it('should show message and active filter icon when there is no data after manua
   );
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await setFilter(container, 'invalid value');
@@ -985,11 +995,11 @@ it('should show message and active filter icon when there is no data after manua
     />,
   );
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(0);
   screen.getByText('No results. Clear filter.');
   const filterIcon = container.querySelector(
-    '.iui-filter-button.iui-active .iui-button-icon',
+    '.iui-table-filter-button.iui-active .iui-button-icon',
   ) as HTMLElement;
   expect(filterIcon).toBeTruthy();
 });
@@ -1051,15 +1061,15 @@ it('should render filter dropdown in the correct document', async () => {
   expect(container.querySelector('.iui-table')).toBeTruthy();
 
   const filterToggle = container.querySelector(
-    '.iui-filter-button',
+    '.iui-table-filter-button',
   ) as HTMLElement;
   expect(filterToggle).toBeTruthy();
   act(() => filterToggle.click());
 
   await waitFor(() =>
-    expect(mockDocument.querySelector('.iui-column-filter')).toBeTruthy(),
+    expect(mockDocument.querySelector('.iui-table-column-filter')).toBeTruthy(),
   );
-  expect(document.querySelector('.iui-column-filter')).toBeFalsy();
+  expect(document.querySelector('.iui-table-column-filter')).toBeFalsy();
 });
 
 it('should rerender table when columns change', async () => {
@@ -1184,16 +1194,16 @@ it('should disable row and handle expansion accordingly', async () => {
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
-  expect(rows[0].classList).not.toContain('iui-disabled');
-  expect(rows[1].classList).toContain('iui-disabled');
-  expect(rows[2].classList).not.toContain('iui-disabled');
+  expect(rows[0]).not.toHaveAttribute('aria-disabled', 'true');
+  expect(rows[1]).toHaveAttribute('aria-disabled', 'true');
+  expect(rows[2]).not.toHaveAttribute('aria-disabled', 'true');
 
-  const disabledRowCells = rows[1].querySelectorAll('.iui-cell');
+  const disabledRowCells = rows[1].querySelectorAll('.iui-table-cell');
   expect(disabledRowCells.length).toBe(4);
   disabledRowCells.forEach((cell) =>
-    expect(cell.classList).toContain('iui-disabled'),
+    expect(cell).toHaveAttribute('aria-disabled', 'true'),
   );
 
   const expansionCells = container.querySelectorAll(
@@ -1222,16 +1232,16 @@ it('should disable row and handle selection accordingly', async () => {
   });
 
   expect(screen.queryByText('Header name')).toBeFalsy();
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
-  expect(rows[0].classList).not.toContain('iui-disabled');
-  expect(rows[1].classList).toContain('iui-disabled');
-  expect(rows[2].classList).not.toContain('iui-disabled');
+  expect(rows[0]).not.toHaveAttribute('aria-disabled', 'true');
+  expect(rows[1]).toHaveAttribute('aria-disabled', 'true');
+  expect(rows[2]).not.toHaveAttribute('aria-disabled', 'true');
 
-  const disabledRowCells = rows[1].querySelectorAll('.iui-cell');
+  const disabledRowCells = rows[1].querySelectorAll('.iui-table-cell');
   expect(disabledRowCells.length).toBe(4);
   disabledRowCells.forEach((cell) =>
-    expect(cell.classList).toContain('iui-disabled'),
+    expect(cell).toHaveAttribute('aria-disabled', 'true'),
   );
 
   const checkboxCells = container.querySelectorAll('.iui-slot .iui-checkbox');
@@ -1291,7 +1301,7 @@ it('should select and filter rows', async () => {
     onSelect,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   let checkboxCells = container.querySelectorAll('.iui-slot .iui-checkbox');
@@ -1341,7 +1351,7 @@ it('should pass custom props to row', () => {
   };
   const { container } = renderComponent({ rowProps });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   fireEvent.mouseEnter(rows[0]);
@@ -1355,7 +1365,9 @@ it.each(['condensed', 'extra-condensed'] as const)(
     const { container } = renderComponent({
       density: density,
     });
-    expect(container.querySelector(`.iui-table.iui-${density}`)).toBeTruthy();
+    expect(
+      container.querySelector('.iui-table')?.getAttribute('data-iui-size'),
+    ).toBe(density);
   },
 );
 
@@ -1364,12 +1376,12 @@ it('should render sub-rows and handle expansions', async () => {
   const data = mockedSubRowsData();
   const { container } = renderComponent({ data, onExpand });
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows, data);
 
   await expandAll(container);
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows, flattenData(data));
 
   expect(onExpand).toHaveBeenNthCalledWith(1, [data[0]], expect.any(Object));
@@ -1416,11 +1428,11 @@ it('should render filtered sub-rows', async () => {
 
   await expandAll(container);
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows, flattenData(data));
 
   await setFilter(container, '2');
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows, [
     { name: 'Row 1', description: 'Description 1' },
     { name: 'Row 1.2', description: 'Description 1.2' },
@@ -1432,7 +1444,7 @@ it('should render filtered sub-rows', async () => {
   ]);
 
   await clearFilter(container);
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows, flattenData(data));
 });
 
@@ -1445,7 +1457,7 @@ it('should handle sub-rows selection', async () => {
     isSelectable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   let checkboxes = container.querySelectorAll<HTMLInputElement>(
@@ -1479,7 +1491,7 @@ it('should show indeterminate checkbox when some sub-rows are selected', async (
     isSelectable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await expandAll(container);
@@ -1515,7 +1527,7 @@ it('should show indeterminate checkbox when a sub-row of a sub-row is selected',
     isSelectable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await expandAll(container);
@@ -1580,7 +1592,7 @@ it('should show indeterminate checkbox when sub-row selected after filtering', a
     isSelectable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await setFilter(container, '2');
@@ -1643,13 +1655,13 @@ it('should show indeterminate checkbox when clicking on a row itself after filte
     isSelectable: true,
   });
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await setFilter(container, '2');
   await expandAll(container);
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(7);
   // Click row 1
   await userEvent.click(rows[0]);
@@ -1679,7 +1691,7 @@ it('should only select one row even if it has sub-rows when selectSubRows is fal
     selectSubRows: false,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   let checkboxes = container.querySelectorAll<HTMLInputElement>(
@@ -1718,14 +1730,14 @@ it('should render sub-rows with custom expander', async () => {
     },
   });
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   await userEvent.click(screen.getByText('Expand Row 1'));
   await userEvent.click(screen.getByText('Expand Row 1.2'));
   await userEvent.click(screen.getByText('Expand Row 2'));
 
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(10);
 });
 
@@ -1762,11 +1774,11 @@ it('should edit cell data', async () => {
     columns,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   await assertRowsData(rows);
 
   const editableCells = container.querySelectorAll(
-    '.iui-cell[contenteditable]',
+    '.iui-table-cell[contenteditable]',
   );
   expect(editableCells).toHaveLength(3);
 
@@ -1813,11 +1825,11 @@ it('should handle unwanted actions on editable cell', async () => {
     onSelect,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   const editableCells = container.querySelectorAll(
-    '.iui-cell[contenteditable]',
+    '.iui-table-cell[contenteditable]',
   );
   expect(editableCells).toHaveLength(3);
 
@@ -1851,20 +1863,28 @@ it('should render data in pages', async () => {
     paginatorRenderer: (props) => <TablePaginator {...props} />,
   });
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows).toHaveLength(10);
-  expect(rows[0].querySelector('.iui-cell')?.textContent).toEqual('Name1');
-  expect(rows[9].querySelector('.iui-cell')?.textContent).toEqual('Name10');
+  expect(rows[0].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name1',
+  );
+  expect(rows[9].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name10',
+  );
 
   const pages = container.querySelectorAll<HTMLButtonElement>(
-    '.iui-paginator .iui-paginator-page-button',
+    '.iui-table-paginator .iui-table-paginator-page-button',
   );
   expect(pages).toHaveLength(10);
   await userEvent.click(pages[3]);
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows).toHaveLength(10);
-  expect(rows[0].querySelector('.iui-cell')?.textContent).toEqual('Name31');
-  expect(rows[9].querySelector('.iui-cell')?.textContent).toEqual('Name40');
+  expect(rows[0].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name31',
+  );
+  expect(rows[9].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name40',
+  );
 });
 
 it('should change page size', async () => {
@@ -1875,10 +1895,14 @@ it('should change page size', async () => {
     ),
   });
 
-  let rows = container.querySelectorAll('.iui-table-body .iui-row');
+  let rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows).toHaveLength(25);
-  expect(rows[0].querySelector('.iui-cell')?.textContent).toEqual('Name1');
-  expect(rows[24].querySelector('.iui-cell')?.textContent).toEqual('Name25');
+  expect(rows[0].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name1',
+  );
+  expect(rows[24].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name25',
+  );
 
   const pageSizeSelector = container.querySelector(
     '.iui-dropdown',
@@ -1887,10 +1911,14 @@ it('should change page size', async () => {
   await userEvent.click(pageSizeSelector);
 
   await userEvent.click(screen.getByText('50 per page'));
-  rows = container.querySelectorAll('.iui-table-body .iui-row');
+  rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows).toHaveLength(50);
-  expect(rows[0].querySelector('.iui-cell')?.textContent).toEqual('Name1');
-  expect(rows[49].querySelector('.iui-cell')?.textContent).toEqual('Name50');
+  expect(rows[0].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name1',
+  );
+  expect(rows[49].querySelector('.iui-table-cell')?.textContent).toEqual(
+    'Name50',
+  );
 });
 
 it('should handle resize by increasing width of current column and decreasing the next ones', () => {
@@ -1924,10 +1952,12 @@ it('should handle resize by increasing width of current column and decreasing th
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   fireEvent.mouseDown(resizer, { clientX: 100 });
@@ -1935,7 +1965,7 @@ it('should handle resize by increasing width of current column and decreasing th
   fireEvent.mouseUp(resizer);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
 
@@ -1975,10 +2005,12 @@ it('should handle resize with touch', () => {
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   fireEvent.touchStart(resizer, { touches: [{ clientX: 100 }] });
@@ -1986,7 +2018,7 @@ it('should handle resize with touch', () => {
   fireEvent.touchEnd(resizer);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
 
@@ -2026,10 +2058,12 @@ it('should prevent from resizing past 1px width', () => {
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   fireEvent.mouseDown(resizer, { clientX: 100 });
@@ -2038,7 +2072,7 @@ it('should prevent from resizing past 1px width', () => {
   fireEvent.mouseUp(resizer);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
 
@@ -2080,10 +2114,12 @@ it('should prevent from resizing past max-width', () => {
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   // Current column
@@ -2093,7 +2129,7 @@ it('should prevent from resizing past max-width', () => {
   fireEvent.mouseUp(resizer);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
 
@@ -2145,10 +2181,12 @@ it('should prevent from resizing past min-width', () => {
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   // Current column
@@ -2158,7 +2196,7 @@ it('should prevent from resizing past min-width', () => {
   fireEvent.mouseUp(resizer);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
 
@@ -2215,11 +2253,13 @@ it('should not resize column with disabled resize but resize closest ones', () =
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   // Current column
-  const nameResizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const nameResizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(nameResizer).toBeTruthy();
 
   fireEvent.mouseDown(nameResizer, { clientX: 100 });
@@ -2227,7 +2267,7 @@ it('should not resize column with disabled resize but resize closest ones', () =
   fireEvent.mouseUp(nameResizer);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(4);
 
@@ -2239,13 +2279,13 @@ it('should not resize column with disabled resize but resize closest ones', () =
   // Description column shouldn't have resizer because resizing is disabled for it
   // and next column also isn't resizable
   const descriptionResizer = container.querySelector(
-    '.iui-cell:nth-of-type(2) .iui-resizer',
+    '.iui-table-cell:nth-of-type(2) .iui-table-resizer',
   ) as HTMLDivElement;
   expect(descriptionResizer).toBeFalsy();
 
   // Last column
   const viewResizer = container.querySelector(
-    '.iui-cell:nth-of-type(3) .iui-resizer',
+    '.iui-table-cell:nth-of-type(3) .iui-table-resizer',
   ) as HTMLDivElement;
   expect(viewResizer).toBeTruthy();
 
@@ -2291,11 +2331,11 @@ it('should not show resizer when there are no next resizable columns', () => {
     isResizable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   const descriptionResizer = container.querySelector(
-    '.iui-cell:nth-of-type(2) .iui-resizer',
+    '.iui-table-cell:nth-of-type(2) .iui-table-resizer',
   ) as HTMLDivElement;
   expect(descriptionResizer).toBeFalsy();
 });
@@ -2334,10 +2374,12 @@ it('should not trigger sort when resizing', () => {
     onSort,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   fireEvent.mouseDown(resizer, { clientX: 100 });
@@ -2391,12 +2433,14 @@ it('should handle table resize only when some columns were resized', () => {
   triggerResize({ width: 300 } as DOMRectReadOnly);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
   headerCells.forEach((cell) => expect(cell.style.width).toBe('0px'));
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   fireEvent.mouseDown(resizer, { clientX: 100 });
@@ -2414,11 +2458,13 @@ it('should not render resizer when resizer is disabled', () => {
   const { container } = renderComponent(undefined);
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells).toHaveLength(3);
 
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeFalsy();
 });
 
@@ -2501,7 +2547,7 @@ it.each([
     );
 
     const headerCells = container.querySelectorAll<HTMLDivElement>(
-      '.iui-table-header .iui-cell',
+      '.iui-table-header .iui-table-cell',
     );
     headerCells.forEach((cell) =>
       expect(cell.getAttribute('draggable')).toBe('true'),
@@ -2515,11 +2561,11 @@ it.each([
     fireEvent.dragOver(dstColumn);
     // If dragging over itself
     if (srcIndex === dstIndex) {
-      expect(dstColumn).not.toHaveClass('iui-reorder-column-left');
-      expect(dstColumn).not.toHaveClass('iui-reorder-column-right');
+      expect(dstColumn).not.toHaveClass('iui-table-reorder-column-left');
+      expect(dstColumn).not.toHaveClass('iui-table-reorder-column-right');
     } else {
       expect(dstColumn).toHaveClass(
-        'iui-reorder-column-' + (srcIndex < dstIndex ? 'right' : 'left'),
+        'iui-table-reorder-column-' + (srcIndex < dstIndex ? 'right' : 'left'),
       );
     }
     fireEvent.drop(dstColumn);
@@ -2540,7 +2586,7 @@ it.each([
     );
 
     container
-      .querySelectorAll<HTMLDivElement>('.iui-table-header .iui-cell')
+      .querySelectorAll<HTMLDivElement>('.iui-table-header .iui-table-cell')
       .forEach((cell, index) =>
         expect(cell.textContent).toBe(resultingColumns[index]),
       );
@@ -2586,7 +2632,7 @@ it('should not have `draggable` attribute on columns with `disableReordering` en
   );
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   expect(headerCells[0].getAttribute('draggable')).toBeFalsy(); // Selection column
   expect(headerCells[1].getAttribute('draggable')).toBeFalsy(); // Expander column
@@ -2624,7 +2670,7 @@ it('should render empty action column', () => {
   });
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
 
   expect(headerCells).toHaveLength(4);
@@ -2661,7 +2707,7 @@ it('should render empty action column with column manager', async () => {
   });
 
   const headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
   const columnManager = headerCells[headerCells.length - 1]
     .firstElementChild as Element;
@@ -2750,7 +2796,7 @@ it('should hide column when deselected in column manager', async () => {
   });
 
   let headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
 
   expect(headerCells).toHaveLength(4);
@@ -2766,7 +2812,7 @@ it('should hide column when deselected in column manager', async () => {
   await userEvent.click(columnManagerColumns[1]);
 
   headerCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-cell',
+    '.iui-table-header .iui-table-cell',
   );
 
   expect(headerCells).toHaveLength(3);
@@ -2809,7 +2855,7 @@ it('should be disabled in column manager if `disableToggleVisibility` is true', 
   const columnManagerColumns = document.querySelectorAll<HTMLLIElement>(
     '.iui-menu-item',
   );
-  expect(columnManagerColumns[0].classList).toContain('iui-disabled');
+  expect(columnManagerColumns[0]).toHaveAttribute('aria-disabled', 'true');
 
   expect(
     (columnManagerColumns[0].querySelector('.iui-checkbox') as HTMLInputElement)
@@ -2844,7 +2890,7 @@ it('should add selection column manually', () => {
     isSelectable: true,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   const checkboxes = container.querySelectorAll<HTMLInputElement>(
@@ -2891,11 +2937,11 @@ it('should add expander column manually', () => {
     onExpand,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   const expanders = container.querySelectorAll<HTMLButtonElement>(
-    '.iui-row-expander',
+    '.iui-table-row-expander',
   );
   expect(expanders.length).toBe(3);
   expect(expanders[0].disabled).toBe(false);
@@ -2934,11 +2980,11 @@ it('should add disabled column', () => {
     columns,
   });
 
-  const disabledCell = container.querySelector(
-    '.iui-cell.iui-disabled',
-  ) as HTMLElement;
+  const disabledCell = Array.from(
+    container.querySelectorAll('.iui-table-cell'),
+  ).find((e) => e.getAttribute('aria-disabled') === 'true');
   expect(disabledCell).toBeTruthy();
-  expect(disabledCell.textContent).toBe('Name2');
+  expect(disabledCell && disabledCell.textContent).toBe('Name2');
 });
 
 it('should show column enabled when whole row is disabled', () => {
@@ -2969,16 +3015,16 @@ it('should show column enabled when whole row is disabled', () => {
     isRowDisabled,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
-  expect(rows[0].classList).not.toContain('iui-disabled');
-  expect(rows[1].classList).toContain('iui-disabled');
-  expect(rows[2].classList).not.toContain('iui-disabled');
+  expect(rows[0]).not.toHaveAttribute('aria-disabled', 'true');
+  expect(rows[1]).toHaveAttribute('aria-disabled', 'true');
+  expect(rows[2]).not.toHaveAttribute('aria-disabled', 'true');
 
-  const rowCells = rows[1].querySelectorAll('.iui-cell');
+  const rowCells = rows[1].querySelectorAll('.iui-table-cell');
   expect(rowCells.length).toBe(2);
-  expect(rowCells[0].classList).not.toContain('iui-disabled');
-  expect(rowCells[1].classList).toContain('iui-disabled');
+  expect(rowCells[0]).not.toHaveAttribute('aria-disabled', 'true');
+  expect(rowCells[1]).toHaveAttribute('aria-disabled', 'true');
 });
 
 it('should render selectable rows without select column', async () => {
@@ -2989,26 +3035,26 @@ it('should render selectable rows without select column', async () => {
     onRowClick,
   });
 
-  const rows = container.querySelectorAll('.iui-table-body .iui-row');
+  const rows = container.querySelectorAll('.iui-table-body .iui-table-row');
   expect(rows.length).toBe(3);
 
   expect(container.querySelectorAll('.iui-slot .iui-checkbox').length).toBe(0);
 
   await userEvent.click(getByText(mockedData()[1].name));
-  expect(rows[1].classList).toContain('iui-selected');
+  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
   expect(onRowClick).toHaveBeenCalledTimes(1);
 
   await userEvent.click(getByText(mockedData()[2].name));
-  expect(rows[1].classList).not.toContain('iui-selected');
-  expect(rows[2].classList).toContain('iui-selected');
+  expect(rows[1]).not.toHaveAttribute('aria-selected', 'true');
+  expect(rows[2]).toHaveAttribute('aria-selected', 'true');
   expect(onRowClick).toHaveBeenCalledTimes(2);
 
   //Test that ctrl clicking doesn't highlight more than one row
   const user = userEvent.setup();
   await user.keyboard('[ControlLeft>]'); // Press Control (without releasing it)
   await user.click(getByText(mockedData()[1].name)); // Perform a click with `ctrlKey: true`
-  expect(rows[1].classList).toContain('iui-selected');
-  expect(rows[2].classList).not.toContain('iui-selected');
+  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
+  expect(rows[2]).not.toHaveAttribute('aria-selected', 'true');
   expect(onRowClick).toHaveBeenCalledTimes(3);
 });
 
@@ -3029,7 +3075,9 @@ it('should not throw on headless table', () => {
     columns,
   });
 
-  expect(container.querySelector('.iui-table-header .iui-row')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-header .iui-table-row'),
+  ).toBeFalsy();
   expect(container.querySelector('.iui-table-body')).toBeTruthy();
 });
 
@@ -3072,21 +3120,21 @@ it('should render sticky columns correctly', () => {
   });
 
   const leftSideStickyCells = container.querySelectorAll(
-    '.iui-cell-sticky:first-of-type',
+    '.iui-table-cell-sticky:first-of-type',
   );
   expect(leftSideStickyCells.length).toBe(4);
   leftSideStickyCells.forEach((cell) => {
-    expect(cell.querySelector('.iui-cell-shadow-left')).toBeFalsy();
-    expect(cell.querySelector('.iui-cell-shadow-right')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-left')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-right')).toBeFalsy();
   });
 
   const rightSideStickyCells = container.querySelectorAll(
-    '.iui-cell-sticky:last-of-type',
+    '.iui-table-cell-sticky:last-of-type',
   );
   expect(rightSideStickyCells.length).toBe(4);
   rightSideStickyCells.forEach((cell) => {
-    expect(cell.querySelector('.iui-cell-shadow-left')).toBeTruthy();
-    expect(cell.querySelector('.iui-cell-shadow-right')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-left')).toBeTruthy();
+    expect(cell.querySelector('.iui-table-cell-shadow-right')).toBeFalsy();
   });
 
   // Scroll a bit to the right
@@ -3097,14 +3145,14 @@ it('should render sticky columns correctly', () => {
 
   expect(leftSideStickyCells.length).toBe(4);
   leftSideStickyCells.forEach((cell) => {
-    expect(cell.querySelector('.iui-cell-shadow-left')).toBeFalsy();
-    expect(cell.querySelector('.iui-cell-shadow-right')).toBeTruthy();
+    expect(cell.querySelector('.iui-table-cell-shadow-left')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-right')).toBeTruthy();
   });
 
   expect(rightSideStickyCells.length).toBe(4);
   rightSideStickyCells.forEach((cell) => {
-    expect(cell.querySelector('.iui-cell-shadow-left')).toBeTruthy();
-    expect(cell.querySelector('.iui-cell-shadow-right')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-left')).toBeTruthy();
+    expect(cell.querySelector('.iui-table-cell-shadow-right')).toBeFalsy();
   });
 
   // Scroll to the very right
@@ -3114,14 +3162,14 @@ it('should render sticky columns correctly', () => {
 
   expect(leftSideStickyCells.length).toBe(4);
   leftSideStickyCells.forEach((cell) => {
-    expect(cell.querySelector('.iui-cell-shadow-left')).toBeFalsy();
-    expect(cell.querySelector('.iui-cell-shadow-right')).toBeTruthy();
+    expect(cell.querySelector('.iui-table-cell-shadow-left')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-right')).toBeTruthy();
   });
 
   expect(rightSideStickyCells.length).toBe(4);
   rightSideStickyCells.forEach((cell) => {
-    expect(cell.querySelector('.iui-cell-shadow-left')).toBeFalsy();
-    expect(cell.querySelector('.iui-cell-shadow-right')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-left')).toBeFalsy();
+    expect(cell.querySelector('.iui-table-cell-shadow-right')).toBeFalsy();
   });
 });
 
@@ -3167,7 +3215,7 @@ it('should have correct sticky left style property', () => {
   });
 
   const nameCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:first-of-type',
+    '.iui-table-cell-sticky:first-of-type',
   );
   expect(nameCells.length).toBe(4);
   nameCells.forEach((cell) => {
@@ -3175,7 +3223,7 @@ it('should have correct sticky left style property', () => {
   });
 
   const descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(2)',
+    '.iui-table-cell-sticky:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3224,7 +3272,7 @@ it('should have correct sticky left style property when prior column does not ha
   });
 
   const nameCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:first-of-type',
+    '.iui-table-cell-sticky:first-of-type',
   );
   expect(nameCells.length).toBe(4);
   nameCells.forEach((cell) => {
@@ -3232,7 +3280,7 @@ it('should have correct sticky left style property when prior column does not ha
   });
 
   const descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(2)',
+    '.iui-table-cell-sticky:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3282,7 +3330,7 @@ it('should have correct sticky right style property', () => {
   });
 
   const descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(2)',
+    '.iui-table-cell-sticky:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3290,7 +3338,7 @@ it('should have correct sticky right style property', () => {
   });
 
   const viewCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(3)',
+    '.iui-table-cell-sticky:nth-of-type(3)',
   );
   expect(viewCells.length).toBe(4);
   viewCells.forEach((cell) => {
@@ -3339,7 +3387,7 @@ it('should have correct sticky right style property when column after does not h
   });
 
   const descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(2)',
+    '.iui-table-cell-sticky:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3347,7 +3395,7 @@ it('should have correct sticky right style property when column after does not h
   });
 
   const viewCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(3)',
+    '.iui-table-cell-sticky:nth-of-type(3)',
   );
   expect(viewCells.length).toBe(4);
   viewCells.forEach((cell) => {
@@ -3398,7 +3446,7 @@ it('should have correct sticky left style property after resizing', () => {
   });
 
   const nameCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:first-of-type',
+    '.iui-table-cell-sticky:first-of-type',
   );
   expect(nameCells.length).toBe(4);
   nameCells.forEach((cell) => {
@@ -3406,7 +3454,7 @@ it('should have correct sticky left style property after resizing', () => {
   });
 
   const descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell-sticky:nth-of-type(2)',
+    '.iui-table-cell-sticky:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3414,7 +3462,9 @@ it('should have correct sticky left style property after resizing', () => {
   });
 
   // Resize
-  const resizer = container.querySelector('.iui-resizer') as HTMLDivElement;
+  const resizer = container.querySelector(
+    '.iui-table-resizer',
+  ) as HTMLDivElement;
   expect(resizer).toBeTruthy();
 
   fireEvent.mouseDown(resizer, { clientX: 400 });
@@ -3471,7 +3521,7 @@ it('should make column sticky and then non-sticky after dragging sticky column a
   });
 
   let nameCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell:first-of-type',
+    '.iui-table-cell:first-of-type',
   );
   expect(nameCells.length).toBe(4);
   nameCells.forEach((cell) => {
@@ -3479,7 +3529,7 @@ it('should make column sticky and then non-sticky after dragging sticky column a
   });
 
   let descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell:nth-of-type(2)',
+    '.iui-table-cell:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3493,7 +3543,7 @@ it('should make column sticky and then non-sticky after dragging sticky column a
   fireEvent.drop(descriptionCells[0]);
 
   nameCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell:nth-of-type(2)',
+    '.iui-table-cell:nth-of-type(2)',
   );
   expect(nameCells.length).toBe(4);
   nameCells.forEach((cell) => {
@@ -3501,7 +3551,7 @@ it('should make column sticky and then non-sticky after dragging sticky column a
   });
 
   descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell:first-of-type',
+    '.iui-table-cell:first-of-type',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {
@@ -3515,7 +3565,7 @@ it('should make column sticky and then non-sticky after dragging sticky column a
   fireEvent.drop(descriptionCells[0]);
 
   nameCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell:first-of-type',
+    '.iui-table-cell:first-of-type',
   );
   expect(nameCells.length).toBe(4);
   nameCells.forEach((cell) => {
@@ -3523,7 +3573,7 @@ it('should make column sticky and then non-sticky after dragging sticky column a
   });
 
   descriptionCells = container.querySelectorAll<HTMLElement>(
-    '.iui-cell:nth-of-type(2)',
+    '.iui-table-cell:nth-of-type(2)',
   );
   expect(descriptionCells.length).toBe(4);
   descriptionCells.forEach((cell) => {

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -712,23 +712,20 @@ export const Table = <
         }}
         id={id}
         {...getTableProps({
-          className: cx(
-            'iui-table',
-            { [`iui-${density}`]: density !== 'default' },
-            className,
-          ),
+          className: cx('iui-table', className),
           style: {
             minWidth: 0, // Overrides the min-width set by the react-table but when we support horizontal scroll it is not needed
             ...style,
           },
         })}
+        data-iui-size={density}
         {...ariaDataAttributes}
       >
         <div className='iui-table-header-wrapper' ref={headerRef}>
           <div className='iui-table-header'>
             {headerGroups.slice(1).map((headerGroup: HeaderGroup<T>) => {
               const headerGroupProps = headerGroup.getHeaderGroupProps({
-                className: 'iui-row',
+                className: 'iui-table-row',
               });
               return (
                 <div {...headerGroupProps} key={headerGroupProps.key}>
@@ -736,11 +733,11 @@ export const Table = <
                     const columnProps = column.getHeaderProps({
                       ...column.getSortByToggleProps(),
                       className: cx(
-                        'iui-cell',
+                        'iui-table-cell',
                         {
                           'iui-actionable': column.canSort,
                           'iui-sorted': column.isSorted,
-                          'iui-cell-sticky': !!column.sticky,
+                          'iui-table-cell-sticky': !!column.sticky,
                         },
                         column.columnClassName,
                       ),
@@ -774,15 +771,15 @@ export const Table = <
                               />
                             )}
                             {showSortButton(column) && (
-                              <div className='iui-cell-end-icon'>
+                              <div className='iui-table-cell-end-icon'>
                                 {column.isSorted && column.isSortedDesc ? (
                                   <SvgSortDown
-                                    className='iui-icon iui-sort'
+                                    className='iui-icon iui-table-sort'
                                     aria-hidden
                                   />
                                 ) : (
                                   <SvgSortUp
-                                    className='iui-icon iui-sort'
+                                    className='iui-icon iui-table-sort'
                                     aria-hidden
                                   />
                                 )}
@@ -795,22 +792,22 @@ export const Table = <
                           index !== headerGroup.headers.length - 1 && (
                             <div
                               {...column.getResizerProps()}
-                              className='iui-resizer'
+                              className='iui-table-resizer'
                             >
-                              <div className='iui-resizer-bar' />
+                              <div className='iui-table-resizer-bar' />
                             </div>
                           )}
                         {enableColumnReordering &&
                           !column.disableReordering && (
-                            <div className='iui-reorder-bar' />
+                            <div className='iui-table-reorder-bar' />
                           )}
                         {column.sticky === 'left' &&
                           state.sticky.isScrolledToRight && (
-                            <div className='iui-cell-shadow-right' />
+                            <div className='iui-table-cell-shadow-right' />
                           )}
                         {column.sticky === 'right' &&
                           state.sticky.isScrolledToLeft && (
-                            <div className='iui-cell-shadow-left' />
+                            <div className='iui-table-cell-shadow-left' />
                           )}
                       </div>
                     );
@@ -835,6 +832,7 @@ export const Table = <
             }
           }}
           tabIndex={-1}
+          aria-multiselectable={isSelectable && selectionMode === 'multi'}
         >
           {data.length !== 0 && (
             <>
@@ -854,8 +852,11 @@ export const Table = <
             </div>
           )}
           {isLoading && data.length !== 0 && (
-            <div className='iui-row'>
-              <div className='iui-cell' style={{ justifyContent: 'center' }}>
+            <div className='iui-table-row'>
+              <div
+                className='iui-table-cell'
+                style={{ justifyContent: 'center' }}
+              >
                 <ProgressRadial
                   indeterminate={true}
                   size='small'

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -718,7 +718,7 @@ export const Table = <
             ...style,
           },
         })}
-        data-iui-size={density}
+        data-iui-size={density === 'default' ? undefined : density}
         {...ariaDataAttributes}
       >
         <div className='iui-table-header-wrapper' ref={headerRef}>
@@ -832,7 +832,9 @@ export const Table = <
             }
           }}
           tabIndex={-1}
-          aria-multiselectable={isSelectable && selectionMode === 'multi'}
+          aria-multiselectable={
+            (isSelectable && selectionMode === 'multi') || undefined
+          }
         >
           {data.length !== 0 && (
             <>

--- a/packages/iTwinUI-react/src/core/Table/TableCell.tsx
+++ b/packages/iTwinUI-react/src/core/Table/TableCell.tsx
@@ -47,8 +47,8 @@ export const TableCell = <T extends Record<string, unknown>>(
   };
 
   const cellElementProps = cell.getCellProps({
-    className: cx('iui-cell', cell.column.cellClassName, {
-      'iui-cell-sticky': !!cell.column.sticky,
+    className: cx('iui-table-cell', cell.column.cellClassName, {
+      'iui-table-cell-sticky': !!cell.column.sticky,
     }),
     style: {
       ...getCellStyle(cell.column, !!tableInstance.state.isTableResizing),
@@ -84,11 +84,11 @@ export const TableCell = <T extends Record<string, unknown>>(
         {cellContent}
         {cell.column.sticky === 'left' &&
           tableInstance.state.sticky.isScrolledToRight && (
-            <div className='iui-cell-shadow-right' />
+            <div className='iui-table-cell-shadow-right' />
           )}
         {cell.column.sticky === 'right' &&
           tableInstance.state.sticky.isScrolledToLeft && (
-            <div className='iui-cell-shadow-left' />
+            <div className='iui-table-cell-shadow-left' />
           )}
       </>
     ),

--- a/packages/iTwinUI-react/src/core/Table/TablePaginator.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/TablePaginator.test.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
 it('should render in its most basic form', () => {
   const { container } = renderComponent();
 
-  const pages = container.querySelectorAll('.iui-paginator-page-button');
+  const pages = container.querySelectorAll('.iui-table-paginator-page-button');
   expect(pages).toHaveLength(20);
   expect(pages[0].classList).toContain('iui-active');
 
@@ -60,7 +60,7 @@ it('should render currently visible rows info and page size selector', async () 
     onPageSizeChange,
   });
 
-  const pages = container.querySelectorAll('.iui-paginator-page-button');
+  const pages = container.querySelectorAll('.iui-table-paginator-page-button');
   expect(pages).toHaveLength(20);
   expect(pages[19].classList).toContain('iui-active');
 
@@ -101,7 +101,9 @@ it('should render without page list', () => {
 it('should render without page list and page size list', () => {
   const { container } = renderComponent({ totalRowsCount: 10 });
 
-  const paginator = container.querySelector('.iui-paginator') as HTMLElement;
+  const paginator = container.querySelector(
+    '.iui-table-paginator',
+  ) as HTMLElement;
   expect(paginator).not.toBeTruthy();
 });
 
@@ -113,10 +115,10 @@ it('should render loading state when there is data', () => {
     isLoading: true,
   });
 
-  const pages = container.querySelectorAll('.iui-paginator-page-button');
+  const pages = container.querySelectorAll('.iui-table-paginator-page-button');
   expect(pages).toHaveLength(20);
   expect(pages[19].classList).toContain('iui-active');
-  expect(container.querySelector('.iui-paginator-ellipsis')).toBeTruthy();
+  expect(container.querySelector('.iui-table-paginator-ellipsis')).toBeTruthy();
   expect(
     container.querySelector('.iui-progress-indicator-radial'),
   ).toBeTruthy();
@@ -141,7 +143,7 @@ it('should render loading state when there is no data', () => {
   });
 
   const pages = container.querySelectorAll<HTMLButtonElement>(
-    '.iui-paginator-page-button',
+    '.iui-table-paginator-page-button',
   );
   expect(pages).toHaveLength(0);
   expect(
@@ -165,7 +167,7 @@ it('should handle clicks', async () => {
   const { container } = renderComponent({ currentPage: 5, onPageChange });
 
   const pages = container.querySelectorAll<HTMLButtonElement>(
-    '.iui-paginator-page-button',
+    '.iui-table-paginator-page-button',
   );
   expect(pages).toHaveLength(20);
   expect(pages[5].classList).toContain('iui-active');
@@ -191,7 +193,7 @@ it('should render truncated pages list', () => {
   jest.spyOn(UseOverflow, 'useOverflow').mockReturnValue([jest.fn(), 5]);
   const { container } = renderComponent({ currentPage: 10 });
 
-  const pages = container.querySelectorAll('.iui-paginator-page-button');
+  const pages = container.querySelectorAll('.iui-table-paginator-page-button');
   expect(pages).toHaveLength(7);
   expect(pages[0].textContent).toEqual('1');
   expect(pages[1].textContent).toEqual('9');
@@ -202,7 +204,7 @@ it('should render truncated pages list', () => {
   expect(pages[5].textContent).toEqual('13');
   expect(pages[6].textContent).toEqual('20');
 
-  const ellipsis = container.querySelectorAll('.iui-paginator-ellipsis');
+  const ellipsis = container.querySelectorAll('.iui-table-paginator-ellipsis');
   expect(ellipsis).toHaveLength(2);
 });
 
@@ -210,12 +212,12 @@ it('should render only the current page when screen is very small', () => {
   jest.spyOn(UseOverflow, 'useOverflow').mockReturnValue([jest.fn(), 1]);
   const { container } = renderComponent({ currentPage: 10 });
 
-  const pages = container.querySelectorAll('.iui-paginator-page-button');
+  const pages = container.querySelectorAll('.iui-table-paginator-page-button');
   expect(pages).toHaveLength(1);
   expect(pages[0].textContent).toEqual('11');
   expect(pages[0].classList).toContain('iui-active');
 
-  const ellipsis = container.querySelectorAll('.iui-paginator-ellipsis');
+  const ellipsis = container.querySelectorAll('.iui-table-paginator-ellipsis');
   expect(ellipsis).toHaveLength(0);
 });
 
@@ -228,7 +230,7 @@ it('should handle keyboard navigation when focusActivationMode is auto', () => {
   });
 
   const buttonGroup = container.querySelector(
-    '.iui-paginator-pages-group',
+    '.iui-table-paginator-pages-group',
   ) as HTMLElement;
   expect(buttonGroup).toBeTruthy();
 
@@ -250,7 +252,7 @@ it('should handle keyboard navigation when focusActivationMode is manual', () =>
   });
 
   const buttonGroup = container.querySelector(
-    '.iui-paginator-pages-group',
+    '.iui-table-paginator-pages-group',
   ) as HTMLElement;
   expect(buttonGroup).toBeTruthy();
 
@@ -283,10 +285,14 @@ it('should render elements in small size', () => {
     Array.from(pageSwitchers).every((p) => p.classList.contains('iui-small')),
   ).toBe(true);
 
-  const pages = container.querySelectorAll('.iui-paginator-page-button-small');
+  const pages = container.querySelectorAll(
+    '.iui-table-paginator-page-button-small',
+  );
   expect(pages).toHaveLength(7);
 
-  const ellipsis = container.querySelectorAll('.iui-paginator-ellipsis-small');
+  const ellipsis = container.querySelectorAll(
+    '.iui-table-paginator-ellipsis-small',
+  );
   expect(ellipsis).toHaveLength(2);
 });
 
@@ -316,7 +322,7 @@ it('should render with custom localization', async () => {
   expect(pageSizeSelector.textContent).toEqual('1-10 of test 195');
 
   expect(
-    container.querySelector('.iui-paginator-page-size-label'),
+    container.querySelector('.iui-table-paginator-page-size-label'),
   ).toHaveTextContent('Items per test page');
 
   await userEvent.click(pageSizeSelector);
@@ -334,7 +340,9 @@ it('should not show rowsPerPageLabel on narrow widths', () => {
     .mockReturnValue([jest.fn(), 600]);
 
   const { container } = renderComponent();
-  expect(container.querySelector('.iui-paginator-page-size-label')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-paginator-page-size-label'),
+  ).toBeFalsy();
 });
 
 it('should hide rowsPerPageLabel if null is passed', () => {
@@ -345,7 +353,9 @@ it('should hide rowsPerPageLabel if null is passed', () => {
   const { container } = renderComponent({
     localization: { rowsPerPageLabel: null },
   });
-  expect(container.querySelector('.iui-paginator-page-size-label')).toBeFalsy();
+  expect(
+    container.querySelector('.iui-table-paginator-page-size-label'),
+  ).toBeFalsy();
 });
 
 it('should render with custom className and style', () => {
@@ -354,7 +364,9 @@ it('should render with custom className and style', () => {
     style: { color: 'red' },
   });
 
-  const paginator = container.querySelector('.iui-paginator') as HTMLElement;
+  const paginator = container.querySelector(
+    '.iui-table-paginator',
+  ) as HTMLElement;
   expect(paginator).toBeTruthy();
   expect(paginator.classList).toContain('test-class');
   expect(paginator.style.color).toEqual('red');

--- a/packages/iTwinUI-react/src/core/Table/TablePaginator.tsx
+++ b/packages/iTwinUI-react/src/core/Table/TablePaginator.tsx
@@ -145,8 +145,9 @@ export const TablePaginator = (props: TablePaginatorProps) => {
     // Checking `needFocus.current` prevents from focusing page when clicked on previous/next page.
     if (isMounted.current && needFocus.current) {
       const buttonToFocus = Array.from(
-        pageListRef.current?.querySelectorAll('.iui-paginator-page-button') ??
-          [],
+        pageListRef.current?.querySelectorAll(
+          '.iui-table-paginator-page-button',
+        ) ?? [],
       ).find((el) => el.textContent?.trim() === (focusedIndex + 1).toString());
       (buttonToFocus as HTMLButtonElement | undefined)?.focus();
       needFocus.current = false;
@@ -160,9 +161,9 @@ export const TablePaginator = (props: TablePaginatorProps) => {
     (index: number, tabIndex = index === focusedIndex ? 0 : -1) => (
       <button
         key={index}
-        className={cx('iui-paginator-page-button', {
+        className={cx('iui-table-paginator-page-button', {
           'iui-active': index === currentPage,
-          'iui-paginator-page-button-small': buttonSize === 'small',
+          'iui-table-paginator-page-button-small': buttonSize === 'small',
         })}
         onClick={() => onPageChange(index)}
         aria-current={index === currentPage}
@@ -251,8 +252,8 @@ export const TablePaginator = (props: TablePaginatorProps) => {
 
   const ellipsis = (
     <span
-      className={cx('iui-paginator-ellipsis', {
-        'iui-paginator-ellipsis-small': size === 'small',
+      className={cx('iui-table-paginator-ellipsis', {
+        'iui-table-paginator-ellipsis-small': size === 'small',
       })}
     >
       …
@@ -277,7 +278,7 @@ export const TablePaginator = (props: TablePaginatorProps) => {
 
   return (
     <div
-      className={cx('iui-paginator', className)}
+      className={cx('iui-table-paginator', className)}
       ref={paginatorResizeRef}
       {...rest}
     >
@@ -294,7 +295,7 @@ export const TablePaginator = (props: TablePaginatorProps) => {
             <SvgChevronLeft />
           </IconButton>
           <span
-            className='iui-paginator-pages-group'
+            className='iui-table-paginator-pages-group'
             onKeyDown={onKeyDown}
             ref={pageListRef}
           >
@@ -346,7 +347,7 @@ export const TablePaginator = (props: TablePaginatorProps) => {
           <>
             {localization.rowsPerPageLabel !== null &&
               paginatorWidth >= 1024 && (
-                <span className='iui-paginator-page-size-label'>
+                <span className='iui-table-paginator-page-size-label'>
                   {localization.rowsPerPageLabel}
                 </span>
               )}

--- a/packages/iTwinUI-react/src/core/Table/TableRowMemoized.tsx
+++ b/packages/iTwinUI-react/src/core/Table/TableRowMemoized.tsx
@@ -74,14 +74,14 @@ export const TableRow = <T extends Record<string, unknown>>(props: {
     ...userRowProps,
     ...{
       className: cx(
-        'iui-row',
+        'iui-table-row',
         {
-          'iui-selected': row.isSelected,
-          'iui-row-expanded': row.isExpanded && subComponent,
-          'iui-disabled': isDisabled,
+          'iui-table-row-expanded': row.isExpanded && subComponent,
         },
         userRowProps?.className,
       ),
+      'aria-selected': row.isSelected,
+      'aria-disabled': isDisabled,
     },
   };
 
@@ -114,9 +114,8 @@ export const TableRow = <T extends Record<string, unknown>>(props: {
       {subComponent && (
         <WithCSSTransition in={row.isExpanded}>
           <div
-            className={cx('iui-row', 'iui-expanded-content', {
-              'iui-disabled': isDisabled,
-            })}
+            className={cx('iui-table-row', 'iui-table-expanded-content', {})}
+            aria-disabled={isDisabled}
           >
             {subComponent(row)}
           </div>

--- a/packages/iTwinUI-react/src/core/Table/TableRowMemoized.tsx
+++ b/packages/iTwinUI-react/src/core/Table/TableRowMemoized.tsx
@@ -80,8 +80,8 @@ export const TableRow = <T extends Record<string, unknown>>(props: {
         },
         userRowProps?.className,
       ),
-      'aria-selected': row.isSelected,
-      'aria-disabled': isDisabled,
+      'aria-selected': row.isSelected || undefined,
+      'aria-disabled': isDisabled || undefined,
     },
   };
 
@@ -114,7 +114,7 @@ export const TableRow = <T extends Record<string, unknown>>(props: {
       {subComponent && (
         <WithCSSTransition in={row.isExpanded}>
           <div
-            className={cx('iui-table-row', 'iui-table-expanded-content', {})}
+            className={cx('iui-table-row', 'iui-table-expanded-content')}
             aria-disabled={isDisabled}
           >
             {subComponent(row)}

--- a/packages/iTwinUI-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/iTwinUI-react/src/core/Table/cells/DefaultCell.tsx
@@ -44,8 +44,8 @@ export const DefaultCell = <T extends Record<string, unknown>>(
     <div
       {...cellElementProps}
       {...rest}
-      className={cx(cellElementClassName, className, {})}
-      aria-disabled={isDisabled?.(cellProps.row.original)}
+      className={cx(cellElementClassName, className)}
+      aria-disabled={isDisabled?.(cellProps.row.original) || undefined}
       style={{ ...cellElementStyle, ...style }}
     >
       {children}

--- a/packages/iTwinUI-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/iTwinUI-react/src/core/Table/cells/DefaultCell.tsx
@@ -44,9 +44,8 @@ export const DefaultCell = <T extends Record<string, unknown>>(
     <div
       {...cellElementProps}
       {...rest}
-      className={cx(cellElementClassName, className, {
-        'iui-disabled': isDisabled?.(cellProps.row.original),
-      })}
+      className={cx(cellElementClassName, className, {})}
+      aria-disabled={isDisabled?.(cellProps.row.original)}
       style={{ ...cellElementStyle, ...style }}
     >
       {children}

--- a/packages/iTwinUI-react/src/core/Table/columns/expanderColumn.tsx
+++ b/packages/iTwinUI-react/src/core/Table/columns/expanderColumn.tsx
@@ -62,7 +62,7 @@ export const ExpanderColumn = <T extends Record<string, unknown>>(
       } else {
         return (
           <IconButton
-            className='iui-row-expander'
+            className='iui-table-row-expander'
             styleType='borderless'
             size='small'
             onClick={(e) => {

--- a/packages/iTwinUI-react/src/core/Table/filters/BaseFilter.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/BaseFilter.tsx
@@ -36,7 +36,7 @@ export const BaseFilter = (props: BaseFilterProps) => {
 
   return (
     <div
-      className={cx('iui-column-filter', className)}
+      className={cx('iui-table-column-filter', className)}
       style={style}
       // Prevents from triggering sort
       onClick={(e: React.MouseEvent) => {

--- a/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
@@ -58,7 +58,7 @@ export const FilterToggle = <T extends Record<string, unknown>>(
           <IconButton
             styleType='borderless'
             isActive={isVisible || isColumnFiltered}
-            className={cx('iui-filter-button', className)}
+            className={cx('iui-table-filter-button', className)}
             onClick={(e) => {
               setIsVisible((v) => !v);
               // Prevents from triggering sort

--- a/packages/iTwinUI-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
+++ b/packages/iTwinUI-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
@@ -57,12 +57,12 @@ const defaultGetDragAndDropProps = <T extends Record<string, unknown>>(
     position?: 'left' | 'right',
   ) => {
     const columnElement = event.currentTarget as HTMLElement;
-    columnElement.classList.remove('iui-reorder-column-right');
-    columnElement.classList.remove('iui-reorder-column-left');
+    columnElement.classList.remove('iui-table-reorder-column-right');
+    columnElement.classList.remove('iui-table-reorder-column-left');
     if (position === 'left') {
-      columnElement.classList.add('iui-reorder-column-left');
+      columnElement.classList.add('iui-table-reorder-column-left');
     } else if (position === 'right') {
-      columnElement.classList.add('iui-reorder-column-right');
+      columnElement.classList.add('iui-table-reorder-column-right');
     }
   };
 


### PR DESCRIPTION
### **Changes**
- **Data Attribute**
  - `iui-condensed/extra-condensed` replaced with `data-iui-size="condensed/extra-condensed"`
  - `iui-selected` replaced with `aria-selected="true"`
    - `iui-table-body` elements that contain selectable rows now have `aria-multiselectable="true"`
  - `iui-disabled` replaced with `aria-disabled="true"`
- **Class name changes**
  - `iui-paginator-*` changed to `iui-table-paginator-*`
  - `iui-column-filter` changed to `iui-table-column-filter`
  - `iui-filter-button` changed to `iui-table-filter-button`
  - `iui-resizer-*` changed to `iui-table-resizer-*`
  - `iui-sort` changed to `iui-table-sort`
  - `iui-reorder-bar-*` changed to `iui-table-reorder-bar-*`
  - `iui-expanded-content` changed to `iui-table-expanded-content`
  - `iui-row-*` changed to `iui-table-row-*`
  - `iui-cell-*` changed to `iui-table-cell-*`

### **Comments**
- I couldn't find any examples where we use rows with statuses or use the `iui-table-more-options` class like we do in the CSS demos.
- Every row has `aria-disabled` and `aria-selected` attributes even if they are false.   It seems excessive to set these two attributes for every row in a table. I'm not sure if there's a way to only add these attributes if they are true and remove them when they are false.
  - The same goes for every `iui-table-body` having an `aria-multiselectable` attribute and for each `iui-table` having a `data-iui-size` attribute. I don't think they're as big of issues here though since it's only applied once per table.
- The visual tests for Table will not pass because the Button Refactor hasn't been implemented in React yet and I wanted to leave that as a separate PR.