### PR TITLE
feat(User Icon): Update itwinui-css to 1.0.0

### DIFF
--- a/apps/storybook/src/UserIconGroup.test.ts
+++ b/apps/storybook/src/UserIconGroup.test.ts
@@ -18,7 +18,7 @@ describe('UserIconGroup', () => {
       cy.visit('iframe', { qs: { id } });
 
       if (testName.includes('Tooltip')) {
-        cy.get('.iui-user-icon-count').trigger('mouseenter'); // trigger tooltip
+        cy.get('.iui-avatar-count').trigger('mouseenter'); // trigger tooltip
       }
 
       cy.compareSnapshot(testName);

--- a/packages/iTwinUI-react/src/core/Toast/Toast.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/Toast.tsx
@@ -70,7 +70,7 @@ export type ToastProps = {
 };
 
 /**
- * Generic Toast Notification Component
+ * Generic Toast Component
  * @example
  * <Toast type='persisting' content='Job processing completed.' category='positive' link={{onClick:() => {alert('Link callback')}, title:'View the report'}} />
  * <Toast type='temporary' content='Processing completed.' category='positive' />
@@ -226,7 +226,7 @@ export type ToastPresentationProps = Omit<
 > & { onClose?: () => void } & CommonProps;
 
 /**
- * The presentational part of a toast notification, without any animation or logic.
+ * The presentational part of a toast, without any animation or logic.
  * @private
  */
 export const ToastPresentation = (props: ToastPresentationProps) => {

--- a/packages/iTwinUI-react/src/core/UserIcon/UserIcon.test.tsx
+++ b/packages/iTwinUI-react/src/core/UserIcon/UserIcon.test.tsx
@@ -10,7 +10,7 @@ import { defaultStatusTitles, UserIcon, UserIconStatus } from './UserIcon';
 function assertBaseElements(size = 'small', backgroundColor = 'white') {
   const userIconContainer = screen.getByTitle('Terry Rivers');
   expect(userIconContainer.className).toEqual(
-    `iui-user-icon${size !== 'medium' ? ` iui-${size}` : ''}`,
+    `iui-avatar${size !== 'medium' ? ` iui-${size}` : ''}`,
   );
 
   const abbreviation = screen.getByText('TR');
@@ -91,7 +91,7 @@ it('renders with image', () => {
   );
 
   const userIconContainer = screen.getByTitle('Terry Rivers');
-  expect(userIconContainer.className).toEqual('iui-user-icon iui-small');
+  expect(userIconContainer.className).toEqual('iui-avatar iui-small');
   const abbreviation = container.querySelector('.iui-initials');
   expect(abbreviation).toBeFalsy();
   const img = container.querySelector('img');

--- a/packages/iTwinUI-react/src/core/UserIcon/UserIcon.tsx
+++ b/packages/iTwinUI-react/src/core/UserIcon/UserIcon.tsx
@@ -87,7 +87,7 @@ export const UserIcon = (props: UserIconProps) => {
   return (
     <span
       className={cx(
-        'iui-user-icon',
+        'iui-avatar',
         { [`iui-${size}`]: size !== 'medium' },
         className,
       )}

--- a/packages/iTwinUI-react/src/core/UserIconGroup/UserIconGroup.test.tsx
+++ b/packages/iTwinUI-react/src/core/UserIconGroup/UserIconGroup.test.tsx
@@ -46,23 +46,21 @@ it('should render in its most basic state', () => {
     <UserIconGroup>{generateUserIcons(7)}</UserIconGroup>,
   );
   const userGroup = container.querySelector(
-    '.iui-user-icon-list.iui-stacked',
+    '.iui-avatar-list.iui-stacked',
   ) as HTMLElement;
   expect(userGroup).toBeTruthy();
   expect(userGroup.classList).not.toContain(`iui-animated`);
 
   expect(
-    container.querySelectorAll(`.iui-user-icon-list > .iui-user-icon.iui-small`)
+    container.querySelectorAll(`.iui-avatar-list > .iui-avatar.iui-small`)
       .length,
   ).toBe(6);
 
   const userGroupIconCount = container.querySelectorAll(
-    '.iui-user-icon-list > .iui-user-icon',
+    '.iui-avatar-list > .iui-avatar',
   );
   expect(userGroupIconCount.length).toBe(6);
-  const countIcon = container.querySelector(
-    '.iui-user-icon-count',
-  ) as HTMLElement;
+  const countIcon = container.querySelector('.iui-avatar-count') as HTMLElement;
   expect(countIcon.textContent).toBe('2');
 
   expect(userGroup.querySelectorAll('.iui-stroke').length).toBe(6);
@@ -75,9 +73,7 @@ it('should render animated', () => {
       {generateUserIcons(7)}
     </UserIconGroup>,
   );
-  expect(
-    container.querySelector('.iui-user-icon-list.iui-animated'),
-  ).toBeTruthy();
+  expect(container.querySelector('.iui-avatar-list.iui-animated')).toBeTruthy();
 });
 
 it('should render without count icon', () => {
@@ -85,17 +81,17 @@ it('should render without count icon', () => {
     <UserIconGroup iconSize='medium'>{generateUserIcons(6)}</UserIconGroup>,
   );
   const userGroup = container.querySelector(
-    '.iui-user-icon-list.iui-stacked',
+    '.iui-avatar-list.iui-stacked',
   ) as HTMLElement;
   expect(userGroup).toBeTruthy();
   expect(userGroup.classList).not.toContain(`iui-animated`);
 
   const userGroupIconCount = container.querySelectorAll(
-    '.iui-user-icon-list > .iui-user-icon',
+    '.iui-avatar-list > .iui-avatar',
   );
   expect(userGroupIconCount.length).toBe(6);
 
-  expect(container.querySelector('.iui-user-icon-count')).toBeFalsy();
+  expect(container.querySelector('.iui-avatar-count')).toBeFalsy();
 
   expect(userGroup.querySelectorAll('.iui-stroke').length).toBe(6);
   expect(userGroup.querySelectorAll('.iui-initials').length).toBe(6);
@@ -108,18 +104,16 @@ it('should render different length', () => {
     </UserIconGroup>,
   );
   const userGroup = container.querySelector(
-    '.iui-user-icon-list.iui-stacked',
+    '.iui-avatar-list.iui-stacked',
   ) as HTMLElement;
   expect(userGroup).toBeTruthy();
 
   const userGroupIconCount = container.querySelectorAll(
-    '.iui-user-icon-list > .iui-user-icon',
+    '.iui-avatar-list > .iui-avatar',
   );
   expect(userGroupIconCount.length).toBe(4);
 
-  const countIcon = container.querySelector(
-    '.iui-user-icon-count',
-  ) as HTMLElement;
+  const countIcon = container.querySelector('.iui-avatar-count') as HTMLElement;
   expect(countIcon.textContent).toBe('4');
 
   expect(userGroup.querySelectorAll('.iui-stroke').length).toBe(4);
@@ -132,24 +126,18 @@ it('should render animated', () => {
       {generateUserIcons(7)}
     </UserIconGroup>,
   );
-  expect(
-    container.querySelector('.iui-user-icon-list.iui-animated'),
-  ).toBeTruthy();
+  expect(container.querySelector('.iui-avatar-list.iui-animated')).toBeTruthy();
 });
 
 it('should render many icons', () => {
   const { container } = render(
     <UserIconGroup iconSize='medium'>{generateUserIcons(105)}</UserIconGroup>,
   );
+  expect(container.querySelector('.iui-avatar-list.iui-stacked')).toBeTruthy();
   expect(
-    container.querySelector('.iui-user-icon-list.iui-stacked'),
-  ).toBeTruthy();
-  expect(
-    container.querySelectorAll('.iui-user-icon-list > .iui-user-icon').length,
+    container.querySelectorAll('.iui-avatar-list > .iui-avatar').length,
   ).toBe(6);
-  const countIcon = container.querySelector(
-    '.iui-user-icon-count',
-  ) as HTMLElement;
+  const countIcon = container.querySelector('.iui-avatar-count') as HTMLElement;
   expect(countIcon.textContent).toBe('99+');
 });
 
@@ -160,9 +148,7 @@ it('should render not stacked', () => {
     </UserIconGroup>,
   );
 
-  expect(
-    container.querySelector('.iui-user-icon-list.iui-stacked'),
-  ).toBeFalsy();
+  expect(container.querySelector('.iui-avatar-list.iui-stacked')).toBeFalsy();
 });
 
 it.each(['small', 'medium', 'large', 'x-large'] as Array<
@@ -176,7 +162,7 @@ it.each(['small', 'medium', 'large', 'x-large'] as Array<
 
   expect(
     container.querySelectorAll(
-      `.iui-user-icon-list > .iui-user-icon${
+      `.iui-avatar-list > .iui-avatar${
         size !== 'medium' ? `.iui-${size}` : ''
       }`,
     ).length,
@@ -195,7 +181,7 @@ it('should render custom classname', () => {
   );
 
   expect(
-    container.querySelector('.iui-user-icon-list.custom-classname'),
+    container.querySelector('.iui-avatar-list.custom-classname'),
   ).toBeTruthy();
 });
 
@@ -212,7 +198,7 @@ it('should render custom classname for count icon', () => {
 
   expect(
     container.querySelector(
-      '.iui-user-icon-list > .iui-user-icon-count.custom-classname',
+      '.iui-avatar-list > .iui-avatar-count.custom-classname',
     ),
   ).toBeTruthy();
 });

--- a/packages/iTwinUI-react/src/core/UserIconGroup/UserIconGroup.tsx
+++ b/packages/iTwinUI-react/src/core/UserIconGroup/UserIconGroup.tsx
@@ -95,7 +95,7 @@ export const UserIconGroup = (props: UserIconGroupProps) => {
     <>
       <div
         className={cx(
-          'iui-user-icon-list',
+          'iui-avatar-list',
           {
             'iui-animated': animated,
             'iui-stacked': stacked,
@@ -112,9 +112,9 @@ export const UserIconGroup = (props: UserIconGroupProps) => {
             <div
               {...countIconProps}
               className={cx(
-                'iui-user-icon',
+                'iui-avatar',
                 { [`iui-${iconSize}`]: iconSize !== 'medium' },
-                'iui-user-icon-count',
+                'iui-avatar-count',
                 countIconProps?.className,
               )}
             >


### PR DESCRIPTION
- Updated changes made in this [comment](https://github.com/iTwin/iTwinUI/pull/639#:~:text=Components%20renamed%3A%20Path%20of%20imports%20changed%20accordingly) for renamed components
![image](https://user-images.githubusercontent.com/37936169/183958202-11250653-be31-4647-b897-66fbd9091f20.png)
- Renamed `iui-user-icon-*` to `iui-avatar-*`
- `iui-wizard-*` to `iui-stepper-*` is being done in [Adam's Wizard PR](https://github.com/iTwin/iTwinUI-react/pull/769)
- There were no `iui-toast-notification-*`, so I didn't have to change anything there. I did remove two references to 'Toast Notification' so that it just says 'Toast' now
- Some visual and unit tests are failing, but I believe none of them have to do with the user icon/avatar