### PR TITLE
fix: Focus is lost while resizing on overflow

### DIFF
--- a/packages/iTwinUI-react/src/core/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/iTwinUI-react/src/core/Breadcrumbs/Breadcrumbs.tsx
@@ -62,28 +62,6 @@ export const Breadcrumbs = React.forwardRef(
     const [overflowRef, visibleCount] = useOverflow(items);
     const refs = useMergedRefs(overflowRef, ref);
 
-    const Separator = () => (
-      <li className='iui-breadcrumbs-separator' aria-hidden>
-        {separator ?? <SvgChevronRight />}
-      </li>
-    );
-
-    const ListItem = ({ index }: { index: number }) => {
-      const item = items[index];
-      return (
-        <li className={'iui-breadcrumbs-item iui-breadcrumbs-item-overrides'}>
-          {React.isValidElement(item)
-            ? React.cloneElement(item, {
-                'aria-current':
-                  item.props['aria-current'] ?? currentIndex === index
-                    ? 'location'
-                    : undefined,
-              })
-            : item}
-        </li>
-      );
-    };
-
     return (
       <nav
         className={cx('iui-breadcrumbs', className)}
@@ -94,8 +72,8 @@ export const Breadcrumbs = React.forwardRef(
         <ol className='iui-breadcrumbs-list'>
           {visibleCount > 1 && (
             <>
-              <ListItem index={0} />
-              <Separator />
+              <ListItem item={items[0]} isActive={currentIndex === 0} />
+              <Separator separator={separator} />
             </>
           )}
           {items.length - visibleCount > 0 && (
@@ -103,7 +81,7 @@ export const Breadcrumbs = React.forwardRef(
               <li className='iui-breadcrumbs-item iui-breadcrumbs-item-overrides'>
                 <span className='iui-breadcrumbs-text'>…</span>
               </li>
-              <Separator />
+              <Separator separator={separator} />
             </>
           )}
           {items
@@ -119,8 +97,13 @@ export const Breadcrumbs = React.forwardRef(
                   : items.length - 1;
               return (
                 <React.Fragment key={index}>
-                  <ListItem index={index} />
-                  {index < items.length - 1 && <Separator />}
+                  <ListItem
+                    item={items[index]}
+                    isActive={currentIndex === index}
+                  />
+                  {index < items.length - 1 && (
+                    <Separator separator={separator} />
+                  )}
                 </React.Fragment>
               );
             })}
@@ -128,6 +111,31 @@ export const Breadcrumbs = React.forwardRef(
       </nav>
     );
   },
+);
+
+const ListItem = ({
+  item,
+  isActive,
+}: {
+  item: React.ReactNode;
+  isActive: boolean;
+}) => {
+  return (
+    <li className={'iui-breadcrumbs-item iui-breadcrumbs-item-overrides'}>
+      {React.isValidElement(item)
+        ? React.cloneElement(item, {
+            'aria-current':
+              item.props['aria-current'] ?? isActive ? 'location' : undefined,
+          })
+        : item}
+    </li>
+  );
+};
+
+const Separator = ({ separator }: Pick<BreadcrumbsProps, 'separator'>) => (
+  <li className='iui-breadcrumbs-separator' aria-hidden>
+    {separator ?? <SvgChevronRight />}
+  </li>
 );
 
 export default Breadcrumbs;

--- a/packages/iTwinUI-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/iTwinUI-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -102,21 +102,23 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
         ref={refs}
         {...rest}
       >
-        {!!overflowButton && visibleCount < items.length ? (
-          <>
-            {overflowButton && overflowPlacement === 'start' && (
+        <>
+          {visibleCount < items.length &&
+            overflowButton &&
+            overflowPlacement === 'start' && (
               <div>{overflowButton(visibleCount)}</div>
             )}
 
-            {items.slice(0, visibleCount - 1)}
+          {visibleCount < items.length
+            ? items.slice(0, visibleCount - 1)
+            : items}
 
-            {overflowButton && overflowPlacement === 'end' && (
+          {visibleCount < items.length &&
+            overflowButton &&
+            overflowPlacement === 'end' && (
               <div>{overflowButton(visibleCount)}</div>
             )}
-          </>
-        ) : (
-          items
-        )}
+        </>
       </div>
     );
   },

--- a/packages/iTwinUI-react/src/core/utils/components/MiddleTextTruncation.tsx
+++ b/packages/iTwinUI-react/src/core/utils/components/MiddleTextTruncation.tsx
@@ -33,10 +33,10 @@ export const MiddleTextTruncation = (props: MiddleTextTruncationProps) => {
 
   const truncatedText = React.useMemo(() => {
     if (visibleCount < text.length) {
-      return `${text.substr(
+      return `${text.substring(
         0,
         visibleCount - endCharsCount - ELLIPSIS_CHAR.length,
-      )}${ELLIPSIS_CHAR}${text.substr(text.length - endCharsCount)}`;
+      )}${ELLIPSIS_CHAR}${text.substring(text.length - endCharsCount)}`;
     } else {
       return text;
     }


### PR DESCRIPTION
Closes #768 

Previously focus was being lost whenever we were resizing the window (rerender happened) and that is mostly caused if the DOM structure is changing (then even having a `key` on element does not help). Moved elements around, to fix this issue.

`Breadcrumbs`: Moved inner components outside, because they were getting a new ref and as a result on every rerender new DOM was being created, which led to focus being lost.

`ButtonGroup`: Moved conditions a little, so DOM is kept the same

`MiddleTextTruncation`: Found that `substr` is marked as deprecated