### PR TITLE
fix(Slider): `onUpdate` called on thumb keyboard press, keyboard `onChange` called onKeyUp

### DIFF
--- a/apps/storybook/src/Slider.stories.tsx
+++ b/apps/storybook/src/Slider.stories.tsx
@@ -44,8 +44,6 @@ export const Basic: Story<SliderProps> = (args) => {
 
 Basic.args = {
   values: [50],
-  onUpdate: () => console.log('onUpdate'),
-  onChange: () => console.log('onChange'),
 };
 
 export const Range: Story<SliderProps> = (args) => {

--- a/apps/storybook/src/Slider.stories.tsx
+++ b/apps/storybook/src/Slider.stories.tsx
@@ -44,6 +44,8 @@ export const Basic: Story<SliderProps> = (args) => {
 
 Basic.args = {
   values: [50],
+  onUpdate: () => console.log('onUpdate'),
+  onChange: () => console.log('onChange'),
 };
 
 export const Range: Story<SliderProps> = (args) => {

--- a/packages/iTwinUI-react/src/core/ColorPicker/ColorPicker.test.tsx
+++ b/packages/iTwinUI-react/src/core/ColorPicker/ColorPicker.test.tsx
@@ -193,7 +193,8 @@ it('should handle arrow key navigation on hue slider dot', () => {
   // Go right
   fireEvent.keyDown(sliderDot, { key: 'ArrowRight' });
   fireEvent.keyDown(sliderDot, { key: 'ArrowRight' });
-  expect(onSelectionChanged).toHaveBeenCalledTimes(2);
+  fireEvent.keyUp(sliderDot, { key: 'ArrowRight' }); // Releasing keyboard triggers calling onChangeCompleted
+  expect(onSelectionChanged).toHaveBeenCalledTimes(1);
   expect(sliderDot.style.getPropertyValue('left')).toEqual(
     '0.5571030640668524%',
   );
@@ -201,7 +202,8 @@ it('should handle arrow key navigation on hue slider dot', () => {
 
   // Go left
   fireEvent.keyDown(sliderDot, { key: 'ArrowLeft' });
-  expect(onSelectionChanged).toHaveBeenCalledTimes(3);
+  fireEvent.keyUp(sliderDot, { key: 'ArrowLeft' });
+  expect(onSelectionChanged).toHaveBeenCalledTimes(2);
   expect(sliderDot.style.getPropertyValue('left')).toEqual(
     '0.2785515320334262%',
   );
@@ -513,6 +515,7 @@ it('should handle arrow key navigation on opacity slider dot', () => {
 
   // Go left
   fireEvent.keyDown(opacityDot, { key: 'ArrowLeft' });
+  fireEvent.keyUp(opacityDot, { key: 'ArrowLeft' }); // Releasing keyboard triggers calling onChangeCompleted
   expect(onSelectionChanged).toHaveBeenNthCalledWith(
     1,
     ColorValue.create({ h: 0, s: 100, l: 50, a: 0.99 }),
@@ -521,6 +524,7 @@ it('should handle arrow key navigation on opacity slider dot', () => {
 
   // Go right
   fireEvent.keyDown(opacityDot, { key: 'ArrowRight' });
+  fireEvent.keyUp(opacityDot, { key: 'ArrowRight' }); // Releasing keyboard triggers calling onChangeCompleted
   expect(onSelectionChanged).toHaveBeenNthCalledWith(
     2,
     ColorValue.create({ h: 0, s: 100, l: 50, a: 1 }),
@@ -560,6 +564,7 @@ it('should render color picker and handle onChangeCompleted when alpha is false'
 
   // Should handle hue slider change
   fireEvent.keyDown(sliderDot, { key: 'ArrowRight' });
+  fireEvent.keyUp(sliderDot, { key: 'ArrowRight' }); // Releasing keyboard triggers calling onChangeCompleted
   expect(handleOnChange).toHaveBeenCalledWith(
     ColorValue.create({ h: 1, s: 100, l: 50 }),
   );

--- a/packages/iTwinUI-react/src/core/Slider/Slider.test.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.test.tsx
@@ -312,10 +312,17 @@ it('should activate thumb on pointerDown', () => {
   expect(thumb.classList).toContain('iui-active');
 });
 
-it('should process keystrokes when thumb has focus', () => {
+it.only('should process keystrokes when thumb has focus', () => {
+  const handleOnUpdate = jest.fn();
   const handleOnChange = jest.fn();
   const { container } = render(
-    <Slider values={[50]} step={5} setFocus onChange={handleOnChange} />,
+    <Slider
+      values={[50]}
+      step={5}
+      setFocus
+      onUpdate={handleOnUpdate}
+      onChange={handleOnChange}
+    />,
   );
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
@@ -328,33 +335,52 @@ it('should process keystrokes when thumb has focus', () => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('45');
+  expect(handleOnUpdate).toHaveBeenCalledTimes(1);
+  expect(handleOnChange).toHaveBeenCalledTimes(0);
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowDown' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('40');
+  expect(handleOnUpdate).toHaveBeenCalledTimes(2);
+  expect(handleOnChange).toHaveBeenCalledTimes(0);
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    fireEvent.keyUp(thumb, { key: 'ArrowRight' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('45');
+  expect(handleOnUpdate).toHaveBeenCalledTimes(3);
+  expect(handleOnChange).toHaveBeenCalledTimes(1); // onChange called only after all keys released
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+    fireEvent.keyUp(thumb, { key: 'ArrowRight' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('50');
+  expect(handleOnUpdate).toHaveBeenCalledTimes(4);
+  expect(handleOnChange).toHaveBeenCalledTimes(2);
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'Home' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('0');
+  expect(handleOnUpdate).toHaveBeenCalledTimes(5);
+  expect(handleOnChange).toHaveBeenCalledTimes(2);
 
   act(() => {
     fireEvent.keyDown(thumb, { key: 'End' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('100');
-  expect(handleOnChange).toHaveBeenCalledTimes(6);
   expect(document.activeElement).toEqual(thumb);
+  expect(handleOnUpdate).toHaveBeenCalledTimes(6);
+  expect(handleOnChange).toHaveBeenCalledTimes(2);
+
+  act(() => {
+    fireEvent.keyUp(thumb, { key: 'End' });
+  });
+  expect(handleOnUpdate).toHaveBeenCalledTimes(6); // onUpdate not called when key released
+  expect(handleOnChange).toHaveBeenCalledTimes(3);
 });
 
 it('should limit keystrokes processing to adjacent points by default', () => {

--- a/packages/iTwinUI-react/src/core/Slider/Slider.test.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.test.tsx
@@ -312,7 +312,7 @@ it('should activate thumb on pointerDown', () => {
   expect(thumb.classList).toContain('iui-active');
 });
 
-it.only('should process keystrokes when thumb has focus', () => {
+it('should process keystrokes when thumb has focus', () => {
   const handleOnUpdate = jest.fn();
   const handleOnChange = jest.fn();
   const { container } = render(
@@ -450,13 +450,18 @@ it('should limit keystrokes processing by min max when allow-crossing is set', (
     fireEvent.keyDown(thumb, { key: 'End' });
   });
   expect(thumb.getAttribute('aria-valuenow')).toEqual('100');
-  expect(handleOnChange).toHaveBeenCalledTimes(4);
+  expect(handleOnChange).toHaveBeenCalledTimes(0);
 
   // triggering an update with same value should not trigger callback
   act(() => {
     fireEvent.keyDown(thumb, { key: 'End' });
   });
-  expect(handleOnChange).toHaveBeenCalledTimes(4);
+  expect(handleOnChange).toHaveBeenCalledTimes(0);
+
+  act(() => {
+    fireEvent.keyUp(thumb, { key: 'End' });
+  });
+  expect(handleOnChange).toHaveBeenCalledTimes(1); // onChange called only after all keys released
 });
 
 it('should not process keystrokes when slider is disabled', () => {

--- a/packages/iTwinUI-react/src/core/Slider/Slider.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.tsx
@@ -338,7 +338,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     // function called by Thumb keyboard processing
     const onThumbValueChanged = React.useCallback(
-      (index: number, value: number) => {
+      (index: number, value: number, keyboardReleased: boolean) => {
         console.log('onThumbValueChanged');
 
         if (currentValues[index] === value) {
@@ -348,7 +348,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         newValues[index] = value;
         setCurrentValues(newValues);
         onUpdate?.(newValues);
-        onChange?.(newValues);
+        keyboardReleased && onChange?.(newValues);
       },
       [currentValues, onUpdate, onChange],
     );

--- a/packages/iTwinUI-react/src/core/Slider/Slider.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.tsx
@@ -347,12 +347,12 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         if (currentValues[index] === value && !keyboardReleased) {
           return;
         }
-        const newValues = [...currentValues];
-        newValues[index] = value;
 
         if (keyboardReleased) {
-          onChange?.(newValues);
+          onChange?.(currentValues); // currentValues since key release should not change value
         } else {
+          const newValues = [...currentValues];
+          newValues[index] = value;
           onUpdate?.(newValues);
           setCurrentValues(newValues);
         }

--- a/packages/iTwinUI-react/src/core/Slider/Slider.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.tsx
@@ -285,8 +285,6 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
     const updateThumbValue = React.useCallback(
       (event: PointerEvent, callbackType: 'onChange' | 'onUpdate') => {
         if (containerRef.current && undefined !== activeThumbIndex) {
-          // console.log('updateThumbValue: ', callbackType);
-
           const percent = getPercentageOfRectangle(
             containerRef.current.getBoundingClientRect(),
             event.clientX,
@@ -305,7 +303,6 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
               ? onChange?.(newValues)
               : onUpdate?.(newValues);
           } else if ('onChange' === callbackType) {
-            // onUpdate?.(currentValues);
             onChange?.(currentValues);
           }
         }
@@ -328,7 +325,6 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         if (activeThumbIndex === undefined) {
           return;
         }
-        // console.log('handle Pointer move');
         event.preventDefault();
         event.stopPropagation();
         updateThumbValue(event, 'onUpdate');
@@ -339,19 +335,14 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
     // function called by Thumb keyboard processing
     const onThumbValueChanged = React.useCallback(
       (index: number, value: number, keyboardReleased: boolean) => {
-        // console.log('onThumbValueChanged', index, value, keyboardReleased);
-
-        // If the value has not changed and still pressing the keyboard
-        // If keyboard released, need to call onChange, even if value didn't change
-
         if (currentValues[index] === value && !keyboardReleased) {
           return;
         }
 
         if (keyboardReleased) {
-          onChange?.(currentValues); // currentValues since key release should not change value
+          onChange?.(currentValues); // currentValues since key up should not change value but only stop continuous value selection
         } else {
-          const newValues = [...currentValues];
+          const newValues = [...currentValues]; // newValues since key down should change value
           newValues[index] = value;
           onUpdate?.(newValues);
           setCurrentValues(newValues);
@@ -366,12 +357,9 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     const handlePointerUp = React.useCallback(
       (event: PointerEvent) => {
-        // console.log('handlePointerUp');
-
         if (activeThumbIndex === undefined) {
           return;
         }
-        // updateThumbValue(event, 'onUpdate');
         updateThumbValue(event, 'onChange');
         setActiveThumbIndex(undefined);
         event.preventDefault();

--- a/packages/iTwinUI-react/src/core/Slider/Slider.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.tsx
@@ -339,16 +339,23 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
     // function called by Thumb keyboard processing
     const onThumbValueChanged = React.useCallback(
       (index: number, value: number, keyboardReleased: boolean) => {
-        console.log('onThumbValueChanged');
+        // console.log('onThumbValueChanged', index, value, keyboardReleased);
 
-        if (currentValues[index] === value) {
+        // If the value has not changed and still pressing the keyboard
+        // If keyboard released, need to call onChange, even if value didn't change
+
+        if (currentValues[index] === value && !keyboardReleased) {
           return;
         }
         const newValues = [...currentValues];
         newValues[index] = value;
-        setCurrentValues(newValues);
-        onUpdate?.(newValues);
-        keyboardReleased && onChange?.(newValues);
+
+        if (keyboardReleased) {
+          onChange?.(newValues);
+        } else {
+          onUpdate?.(newValues);
+          setCurrentValues(newValues);
+        }
       },
       [currentValues, onUpdate, onChange],
     );

--- a/packages/iTwinUI-react/src/core/Slider/Slider.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Slider.tsx
@@ -285,6 +285,8 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
     const updateThumbValue = React.useCallback(
       (event: PointerEvent, callbackType: 'onChange' | 'onUpdate') => {
         if (containerRef.current && undefined !== activeThumbIndex) {
+          // console.log('updateThumbValue: ', callbackType);
+
           const percent = getPercentageOfRectangle(
             containerRef.current.getBoundingClientRect(),
             event.clientX,
@@ -303,6 +305,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
               ? onChange?.(newValues)
               : onUpdate?.(newValues);
           } else if ('onChange' === callbackType) {
+            // onUpdate?.(currentValues);
             onChange?.(currentValues);
           }
         }
@@ -325,6 +328,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         if (activeThumbIndex === undefined) {
           return;
         }
+        // console.log('handle Pointer move');
         event.preventDefault();
         event.stopPropagation();
         updateThumbValue(event, 'onUpdate');
@@ -335,15 +339,18 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
     // function called by Thumb keyboard processing
     const onThumbValueChanged = React.useCallback(
       (index: number, value: number) => {
+        console.log('onThumbValueChanged');
+
         if (currentValues[index] === value) {
           return;
         }
         const newValues = [...currentValues];
         newValues[index] = value;
         setCurrentValues(newValues);
+        onUpdate?.(newValues);
         onChange?.(newValues);
       },
-      [currentValues, onChange],
+      [currentValues, onUpdate, onChange],
     );
 
     const onThumbActivated = React.useCallback((index: number) => {
@@ -352,9 +359,12 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     const handlePointerUp = React.useCallback(
       (event: PointerEvent) => {
+        // console.log('handlePointerUp');
+
         if (activeThumbIndex === undefined) {
           return;
         }
+        // updateThumbValue(event, 'onUpdate');
         updateThumbValue(event, 'onChange');
         setActiveThumbIndex(undefined);
         event.preventDefault();

--- a/packages/iTwinUI-react/src/core/Slider/Thumb.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Thumb.tsx
@@ -51,7 +51,11 @@ export type ThumbProps = {
   /**
    * Callback to invoke when keyboard is used to modify Thumb value.
    */
-  onThumbValueChanged: (index: number, value: number) => void;
+  onThumbValueChanged: (
+    index: number,
+    value: number,
+    keyboardReleased: boolean,
+  ) => void;
   /**
    * Additional tooltip props.
    */
@@ -85,25 +89,34 @@ export const Thumb = (props: ThumbProps) => {
     orientation,
   } = props;
   const thumbRef = React.useRef<HTMLDivElement>(null);
-  const handleOnKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
+
+  const handleOnKeyboardEvent = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>, keyboardReleased: boolean) => {
       if (disabled || event.altKey) {
         return;
       }
       switch (event.key) {
         case 'ArrowLeft':
         case 'ArrowDown':
-          onThumbValueChanged(index, Math.max(value - step, minVal));
+          onThumbValueChanged(
+            index,
+            Math.max(value - step, minVal),
+            keyboardReleased,
+          );
           break;
         case 'ArrowRight':
         case 'ArrowUp':
-          onThumbValueChanged(index, Math.min(value + step, maxVal));
+          onThumbValueChanged(
+            index,
+            Math.min(value + step, maxVal),
+            keyboardReleased,
+          );
           break;
         case 'Home':
-          onThumbValueChanged(index, minVal);
+          onThumbValueChanged(index, minVal, keyboardReleased);
           break;
         case 'End':
-          onThumbValueChanged(index, maxVal);
+          onThumbValueChanged(index, maxVal, keyboardReleased);
           break;
         default:
           return;
@@ -164,7 +177,8 @@ export const Thumb = (props: ThumbProps) => {
         aria-valuemax={maxVal}
         aria-disabled={disabled}
         onPointerDown={handlePointerDownOnThumb}
-        onKeyDown={handleOnKeyDown}
+        onKeyDown={(event) => handleOnKeyboardEvent(event, false)}
+        onKeyUp={(event) => handleOnKeyboardEvent(event, true)}
         onFocus={() => setHasFocus(true)}
         onBlur={() => setHasFocus(false)}
         onMouseEnter={() => setIsHovered(true)}

--- a/packages/iTwinUI-react/src/core/Slider/Thumb.tsx
+++ b/packages/iTwinUI-react/src/core/Slider/Thumb.tsx
@@ -89,7 +89,6 @@ export const Thumb = (props: ThumbProps) => {
     orientation,
   } = props;
   const thumbRef = React.useRef<HTMLDivElement>(null);
-
   const handleOnKeyboardEvent = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, keyboardReleased: boolean) => {
       if (disabled || event.altKey) {


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #398 <!-- Add issue number -->

## Screenshots

* In the below examples, we're pressing keyboard keys: Up/Right, Down/Left, Home, End

#### Old
  * `onUpdate` not called when pressing keyboard keys
  * `onChange` called multiple times when holding keyboard keys

[vokoscreenNG-2022-10-04_15-25-20.webm](https://user-images.githubusercontent.com/45748283/193908360-6900af7b-1f71-48b5-8004-7daaaa5c32a6.webm)

#### New
  * `onUpdate` called even when pressing keyboard keys
  * `onChange` is only called once after the keyboard key  is released

[vokoscreenNG-2022-10-04_16-22-13.webm](https://user-images.githubusercontent.com/45748283/193918989-9c764c87-9bb4-47a9-b671-b81b962ebb3d.webm)

<!-- [vokoscreenNG-2022-10-04_16-20-17.webm](https://user-images.githubusercontent.com/45748283/193918768-0c89ad8b-e081-41d8-b8c0-220c60e846dd.webm) -->

<!-- [vokoscreenNG-2022-10-04_15-19-23.webm](https://user-images.githubusercontent.com/45748283/193907218-87ef5b04-e01e-4d75-9d13-68f18902faef.webm) -->

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- ~~[ ]~~ Add component features demo in Storybook (different stories)
- ~~[ ]~~ Approve test images for new stories
- [x] Add screenshots of the key elements of the component
