### PR TITLE
chore(Dialog): DialogBackdrop uses `.iui-backdrop-fixed` instead of `position: fixed`

### DIFF
--- a/packages/iTwinUI-react/src/core/Dialog/Dialog.test.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/Dialog.test.tsx
@@ -42,6 +42,52 @@ it('should pass down the props through DialogContext', async () => {
   expect(onClose).toHaveBeenCalledTimes(2);
 });
 
+it('should have position correctly dependant on viewport', async () => {
+  const dialogContent = (
+    <Dialog.Main>
+      <Dialog.TitleBar titleText='Test title' />
+      <Dialog.Content>Here is my dialog content</Dialog.Content>
+      <Dialog.ButtonBar>
+        <Button styleType='high-visibility'>Confirm</Button>
+        <Button>Close</Button>
+      </Dialog.ButtonBar>
+    </Dialog.Main>
+  );
+
+  const containerViewport = render(
+    <Dialog relativeTo='viewport'>
+      <Dialog.Backdrop />
+      {dialogContent}
+    </Dialog>,
+  );
+
+  const containerContainer = render(
+    <Dialog relativeTo='container'>
+      <Dialog.Backdrop />
+      {dialogContent}
+    </Dialog>,
+  );
+
+  const dialogWrapperViewport = containerViewport.container.querySelector(
+    '.iui-dialog-wrapper',
+  ) as HTMLElement;
+  const dialogWrapperContainer = containerContainer.container.querySelector(
+    '.iui-dialog-wrapper',
+  ) as HTMLElement;
+
+  const backdropViewport = containerViewport.container.querySelector(
+    '.iui-backdrop',
+  ) as HTMLElement;
+  const backdropContainer = containerContainer.container.querySelector(
+    '.iui-backdrop',
+  ) as HTMLElement;
+
+  expect(dialogWrapperViewport).toHaveStyle('position: fixed');
+  expect(dialogWrapperContainer).toHaveStyle('position: absolute');
+  expect(backdropViewport).toHaveClass('iui-backdrop-fixed');
+  expect(backdropContainer).not.toHaveClass('iui-backdrop-fixed');
+});
+
 it('should not allow to close the dialog when isDismissible false', async () => {
   const onClose = jest.fn();
   const { container } = render(

--- a/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Backdrop, BackdropProps } from '../Backdrop';
 import { useMergedRefs } from '../utils';
 import { DialogContextProps, useDialogContext } from './DialogContext';
+import cx from 'classnames';
 
 export type DialogBackdropProps = BackdropProps &
   Pick<
@@ -53,11 +54,11 @@ export const DialogBackdrop = React.forwardRef<
   return (
     <Backdrop
       isVisible={isVisible}
+      className={cx({ 'iui-backdrop-fixed': relativeTo === 'viewport' })}
       ref={refs}
       onMouseDown={handleMouseDown}
       style={{
         pointerEvents: 'auto',
-        position: relativeTo === 'container' ? 'absolute' : 'fixed',
         ...style,
       }}
       {...rest}


### PR DESCRIPTION
**[CLOSED]** Moved to #866. This PR is closed as it points to `v2` and not `itwinui-css-v1`

* Implements [v1 (issue #831)](https://github.com/iTwin/iTwinUI-react/issues/831) CSS change: [fix(Dialog): Add `position: fixed` as an option for dialogs](https://github.com/iTwin/iTwinUI/pull/756/commits/bf38b24cd47e7980084bc59546b73049a4a284e3)

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- ~~[ ]~~ Add component features demo in Storybook (different stories)
- ~~[ ]~~ Approve test images for new stories
- ~~[ ]~~ Add screenshots of the key elements of the component