### PR TITLE
fix(Table): Select all indeterminate state

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/Table.test.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.test.tsx
@@ -352,10 +352,10 @@ it('should handle checkbox clicks', async () => {
   expect(onSelect).toHaveBeenCalledWith([mockedData()[1]], expect.any(Object));
 
   await userEvent.click(checkboxCells[0]);
-  expect(onSelect).toHaveBeenCalledWith(mockedData(), expect.any(Object));
+  expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
 
   await userEvent.click(checkboxCells[0]);
-  expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
+  expect(onSelect).toHaveBeenCalledWith(mockedData(), expect.any(Object));
 });
 
 it('should handle row clicks', async () => {
@@ -1853,6 +1853,12 @@ it('should disable row and handle selection accordingly', async () => {
   expect(headerCheckbox.indeterminate).toBe(true);
   expect(headerCheckbox.checked).toBe(false);
 
+  // Deselect all
+  await userEvent.click(checkboxCells[0]);
+  expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
+  expect(headerCheckbox.indeterminate).toBe(false);
+  expect(headerCheckbox.checked).toBe(false);
+
   // Select all
   await userEvent.click(checkboxCells[0]);
   expect(onSelect).toHaveBeenCalledWith(
@@ -1861,12 +1867,6 @@ it('should disable row and handle selection accordingly', async () => {
   );
   expect(headerCheckbox.indeterminate).toBe(false);
   expect(headerCheckbox.checked).toBe(true);
-
-  // Deselect all
-  await userEvent.click(checkboxCells[0]);
-  expect(onSelect).toHaveBeenCalledWith([], expect.any(Object));
-  expect(headerCheckbox.indeterminate).toBe(false);
-  expect(headerCheckbox.checked).toBe(false);
 });
 
 it('should select and filter rows', async () => {

--- a/packages/iTwinUI-react/src/core/Table/columns/selectionColumn.tsx
+++ b/packages/iTwinUI-react/src/core/Table/columns/selectionColumn.tsx
@@ -43,6 +43,7 @@ export const SelectionColumn = <T extends Record<string, unknown>>(
     cellClassName: 'iui-slot',
     Header: ({
       getToggleAllRowsSelectedProps,
+      toggleAllRowsSelected,
       rows,
       initialRows,
       state,
@@ -51,16 +52,17 @@ export const SelectionColumn = <T extends Record<string, unknown>>(
       const checked = initialRows.every(
         (row) => state.selectedRowIds[row.id] || isDisabled?.(row.original),
       );
+      const indeterminate =
+        !checked && Object.keys(state.selectedRowIds).length > 0;
       return (
         <Checkbox
           {...getToggleAllRowsSelectedProps()}
           style={{}} // Removes pointer cursor as we have it in CSS and it is also showing pointer when disabled
           title='' // Removes default title that comes from react-table
           checked={checked && !disabled}
-          indeterminate={
-            !checked && Object.keys(state.selectedRowIds).length > 0
-          }
+          indeterminate={indeterminate}
           disabled={disabled}
+          onChange={() => toggleAllRowsSelected(!checked && !indeterminate)}
         />
       );
     },


### PR DESCRIPTION
Continued from iTwin/iTwinUI-react#861 

- Clicking the "Select all" checkbox when it is in the indeterminate state now unselects all rows.

- Filtered rows can now be deselected with the "Select all" checkbox.

Closes iTwin/iTwinUI-react#731 