### PR TITLE
fix: Add `tippy.js` as a direct dependency

### DIFF
--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -47,11 +47,12 @@
     "@itwin/itwinui-css": "^0.63.0",
     "@itwin/itwinui-icons-react": "^1.10.1",
     "@itwin/itwinui-illustrations-react": "^1.3.1",
-    "@tippyjs/react": "^4.2.5",
+    "@tippyjs/react": "^4.2.6",
     "@types/react-table": "^7.0.18",
     "classnames": "^2.2.6",
     "react-table": "^7.1.0",
-    "react-transition-group": "^4.4.2"
+    "react-transition-group": "^4.4.2",
+    "tippy.js": "^6.3.7"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -79,7 +80,6 @@
     "markdown-to-jsx": "6.11.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "tippy.js": "^6.3.1",
     "ts-jest": "^28.0.2",
     "ts-loader": "^9.2.8",
     "ts-node": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,9 +1828,9 @@
     source-map "^0.7.3"
 
 "@popperjs/core@^2.9.0":
-  version "2.11.5"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
-  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
+  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
 "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
@@ -2882,7 +2882,7 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.0.tgz#8293560f8f80a00383d6c755ec3e0b918acb1683"
   integrity sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==
 
-"@tippyjs/react@^4.2.5":
+"@tippyjs/react@^4.2.6":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.6.tgz#971677a599bf663f20bb1c60a62b9555b749cc71"
   integrity sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==
@@ -12577,7 +12577,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tippy.js@^6.3.1:
+tippy.js@^6.3.1, tippy.js@^6.3.7:
   version "6.3.7"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
   integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==


### PR DESCRIPTION
<!--
Thank you for your contribution to the iTwinUI-react project!
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

tippyjs version 6.3.1 had some bugs in it that are fixed in version 6.3.7. One of which was clicking on a Dropdown would cause an error because "props.onShow is not a function". Upgrading to 6.3.7 resolves the issue.

Closes # <no issue was created>

## Checklist

- [ ] Add meaningful unit tests for your component (verify that all lines are covered) - Code was not modified
- [x] Verify that all existing tests pass
- [ ] Add component features demo in Storybook (different stories) - No new components were added
- [ ] Approve test images for new stories - No new stories were added
- [ ] Add screenshots of the key elements of the component - No components were modified
