### PR TITLE
chore(Dialog): Dialog wrapper uses `data-iui-relative` instead of inline positioning

### DIFF
--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -44,7 +44,7 @@
     "createComponent": "node ../../scripts/createComponent.js"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "1.0.0-dev.7",
+    "@itwin/itwinui-css": "1.0.0-dev.9",
     "@itwin/itwinui-icons-react": "^1.10.1",
     "@itwin/itwinui-illustrations-react": "^1.3.1",
     "@itwin/itwinui-variables": "0.3.0",

--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -44,7 +44,7 @@
     "createComponent": "node ../../scripts/createComponent.js"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "1.0.0-dev.6",
+    "@itwin/itwinui-css": "1.0.0-dev.7",
     "@itwin/itwinui-icons-react": "^1.10.1",
     "@itwin/itwinui-illustrations-react": "^1.3.1",
     "@itwin/itwinui-variables": "0.3.0",

--- a/packages/iTwinUI-react/src/core/Dialog/Dialog.test.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/Dialog.test.tsx
@@ -82,8 +82,8 @@ it('should have position correctly dependant on viewport', async () => {
     '.iui-backdrop',
   ) as HTMLElement;
 
-  expect(dialogWrapperViewport).toHaveStyle('position: fixed');
-  expect(dialogWrapperContainer).toHaveStyle('position: absolute');
+  expect(dialogWrapperViewport).toHaveAttribute('data-iui-relative', 'false');
+  expect(dialogWrapperContainer).toHaveAttribute('data-iui-relative', 'true');
   expect(backdropViewport).toHaveClass('iui-backdrop-fixed');
   expect(backdropContainer).not.toHaveClass('iui-backdrop-fixed');
 });

--- a/packages/iTwinUI-react/src/core/Dialog/Dialog.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/Dialog.tsx
@@ -86,9 +86,9 @@ export const Dialog = Object.assign(
         >
           <div
             className={cx('iui-dialog-wrapper', className)}
+            data-iui-relative={relativeTo === 'container'}
             ref={refs}
             style={{
-              position: relativeTo === 'container' ? 'absolute' : 'fixed',
               ...style,
             }}
             {...rest}

--- a/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
@@ -24,8 +24,6 @@ export const DialogBackdrop = React.forwardRef<
   HTMLDivElement,
   DialogBackdropProps
 >((props, ref) => {
-  const { className } = props;
-
   const dialogContext = useDialogContext();
   const {
     isVisible = dialogContext.isOpen,
@@ -34,6 +32,7 @@ export const DialogBackdrop = React.forwardRef<
     closeOnExternalClick = dialogContext.closeOnExternalClick,
     relativeTo = dialogContext.relativeTo,
     onMouseDown,
+    className,
     style,
     ...rest
   } = props;

--- a/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
@@ -52,13 +52,17 @@ export const DialogBackdrop = React.forwardRef<
     onMouseDown?.(event);
   };
 
+  console.log('className: ', className);
+
   return (
     <Backdrop
       isVisible={isVisible}
-      className={cx({
-        'iui-backdrop-fixed': relativeTo === 'viewport',
+      className={cx(
+        {
+          'iui-backdrop-fixed': relativeTo === 'viewport',
+        },
         className,
-      })}
+      )}
       ref={refs}
       onMouseDown={handleMouseDown}
       style={{

--- a/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogBackdrop.tsx
@@ -52,8 +52,6 @@ export const DialogBackdrop = React.forwardRef<
     onMouseDown?.(event);
   };
 
-  console.log('className: ', className);
-
   return (
     <Backdrop
       isVisible={isVisible}

--- a/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
@@ -200,7 +200,6 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
         style={{
           transform,
           overflow: 'unset',
-          maxWidth: '100%',
           ...style,
           ...propStyle,
         }}
@@ -210,6 +209,7 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
           <Resizer
             elementRef={dialogRef}
             containerRef={dialogContext.dialogRootRef}
+            onResizeStart={() => setResizeStyle({ maxWidth: '100%' })}
             onResizeEnd={setResizeStyle}
           />
         )}

--- a/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
@@ -213,7 +213,6 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
             onResizeStart={() => {
               if (!hasBeenResized.current) {
                 hasBeenResized.current = true;
-                console.log('HERE');
                 setResizeStyle({ maxWidth: '100%' });
               }
             }}

--- a/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
@@ -78,6 +78,7 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
 
     const dialogRef = React.useRef<HTMLDivElement>(null);
     const refs = useMergedRefs(dialogRef, ref);
+    const hasBeenResized = React.useRef(false);
 
     // Focuses dialog when opened and brings back focus to the previously focused element when closed.
     const previousFocusedElement = React.useRef<HTMLElement | null>();
@@ -209,7 +210,13 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
           <Resizer
             elementRef={dialogRef}
             containerRef={dialogContext.dialogRootRef}
-            onResizeStart={() => setResizeStyle({ maxWidth: '100%' })}
+            onResizeStart={() => {
+              if (!hasBeenResized.current) {
+                hasBeenResized.current = true;
+                console.log('HERE');
+                setResizeStyle({ maxWidth: '100%' });
+              }
+            }}
             onResizeEnd={setResizeStyle}
           />
         )}

--- a/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogMain.tsx
@@ -200,6 +200,7 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
         style={{
           transform,
           overflow: 'unset',
+          maxWidth: '100%',
           ...style,
           ...propStyle,
         }}

--- a/packages/iTwinUI-react/src/core/utils/components/Resizer.tsx
+++ b/packages/iTwinUI-react/src/core/utils/components/Resizer.tsx
@@ -19,7 +19,7 @@ export type ResizerProps = {
    * Callback that is being called on resize start.
    * Useful to set state, style, or other properties when resizing is started.
    */
-  onResizeStart?: (style: React.CSSProperties) => void;
+  onResizeStart?: () => void;
   /**
    * Callback that is being called on resize end.
    * Useful to preserve state if element is being closed.
@@ -83,11 +83,7 @@ export const Resizer = (props: ResizerProps) => {
 
       if (!isResizing.current) {
         isResizing.current = true;
-        onResizeStart?.({
-          width,
-          height,
-          transform: `translate(${translateX}px, ${translateY}px)`,
-        });
+        onResizeStart?.();
       }
 
       const containerRect = containerRef?.current?.getBoundingClientRect();

--- a/packages/iTwinUI-react/src/core/utils/components/Resizer.tsx
+++ b/packages/iTwinUI-react/src/core/utils/components/Resizer.tsx
@@ -16,6 +16,11 @@ export type ResizerProps = {
    */
   containerRef?: React.RefObject<HTMLElement>;
   /**
+   * Callback that is being called on resize start.
+   * Useful to set state, style, or other properties when resizing is started.
+   */
+  onResizeStart?: (style: React.CSSProperties) => void;
+  /**
    * Callback that is being called on resize end.
    * Useful to preserve state if element is being closed.
    */
@@ -35,7 +40,9 @@ export type ResizerProps = {
  * );
  */
 export const Resizer = (props: ResizerProps) => {
-  const { elementRef, containerRef, onResizeEnd } = props;
+  const { elementRef, containerRef, onResizeStart, onResizeEnd } = props;
+
+  const isResizing = React.useRef(false);
 
   const onResizePointerDown = (event: React.PointerEvent<HTMLElement>) => {
     if (!elementRef.current || event.button !== 0) {
@@ -72,6 +79,15 @@ export const Resizer = (props: ResizerProps) => {
     const onResizePointerMove = (event: PointerEvent) => {
       if (!elementRef.current) {
         return;
+      }
+
+      if (!isResizing.current) {
+        isResizing.current = true;
+        onResizeStart?.({
+          width,
+          height,
+          transform: `translate(${translateX}px, ${translateY}px)`,
+        });
       }
 
       const containerRect = containerRef?.current?.getBoundingClientRect();
@@ -182,6 +198,7 @@ export const Resizer = (props: ResizerProps) => {
         document.removeEventListener('pointermove', onResizePointerMove);
         if (elementRef.current) {
           elementRef.current.ownerDocument.body.style.userSelect = originalUserSelect;
+          isResizing.current = false;
           onResizeEnd?.({
             width,
             height,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,10 +1415,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@1.0.0-dev.7":
-  version "1.0.0-dev.7"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-1.0.0-dev.7.tgz#fa04c0fe8511c653874ccd151291c60dc7518d95"
-  integrity sha512-XKw1Xl6nBhs/1B3MgOsON2wdkwnkONjfwZT7CjgtHNKWxTiOPXwnNPqUtULWoSG/zMv+es2mEULbA2Kj4iculA==
+"@itwin/itwinui-css@1.0.0-dev.9":
+  version "1.0.0-dev.9"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-1.0.0-dev.9.tgz#4cc835f3f905d65077da6466328968781fcd0593"
+  integrity sha512-mkEAUqO+RBEVZMafWQthpHdJpP2Dna0S8Jn0FUJkviGC+aWikHyeFVGWYrMI/jg+D7jYAXU224Ay4KXc8lhMow==
 
 "@itwin/itwinui-icons-react@^1.10.1":
   version "1.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,10 +1415,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@itwin/itwinui-css@1.0.0-dev.6":
-  version "1.0.0-dev.6"
-  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-1.0.0-dev.6.tgz#53b82a3f042d12eb65c6ee6bdf4515929356693d"
-  integrity sha512-zWxT+tObjY/U2Q7DKtzFTRGeZbyfCaCgQgjzRg7BGKk265/O616WxupwekyYP6hLzkrvS9GtotIrnixRVeQing==
+"@itwin/itwinui-css@1.0.0-dev.7":
+  version "1.0.0-dev.7"
+  resolved "https://registry.yarnpkg.com/@itwin/itwinui-css/-/itwinui-css-1.0.0-dev.7.tgz#fa04c0fe8511c653874ccd151291c60dc7518d95"
+  integrity sha512-XKw1Xl6nBhs/1B3MgOsON2wdkwnkONjfwZT7CjgtHNKWxTiOPXwnNPqUtULWoSG/zMv+es2mEULbA2Kj4iculA==
 
 "@itwin/itwinui-icons-react@^1.10.1":
   version "1.10.1"


### PR DESCRIPTION
* Implements [v1 (issue #831)](https://github.com/iTwin/iTwinUI-react/issues/831) CSS change: [fix: Make dialog positioned and remove unneeded styles](https://github.com/iTwin/iTwinUI/pull/756/commits/da810533f758fae1a0e8a61ad4144a88519be178)
* Dialog wrapper sets `data-iui-relative={relativeTo === 'container'}` instead of inline style `position: relativeTo === 'container' ? 'absolute' : 'fixed'`
* Removes double prop deconstruction in `DialogBackdrop.tsx` that happened due to PR [#866](https://github.com/iTwin/iTwinUI-react/pull/866) as mentioned in [#866 (comment)](https://github.com/iTwin/iTwinUI-react/pull/866#discussion_r993542560)

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
  - **IGNORING** `Select -> Truncate Middle Text` since it even fails before this PR.
- ~[ ]~ Add component features demo in Storybook (different stories)
- ~[ ]~ Approve test images for new stories
- ~[ ]~ Add screenshots of the key elements of the component
