### PR TITLE
fix(Table): Select all rows for current filter

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/columns/selectionColumn.tsx
+++ b/packages/iTwinUI-react/src/core/Table/columns/selectionColumn.tsx
@@ -62,7 +62,9 @@ export const SelectionColumn = <T extends Record<string, unknown>>(
           checked={checked && !disabled}
           indeterminate={indeterminate}
           disabled={disabled}
-          onChange={() => toggleAllRowsSelected(!checked && !indeterminate)}
+          onChange={() =>
+            toggleAllRowsSelected(!rows.some((row) => row.isSelected))
+          }
         />
       );
     },


### PR DESCRIPTION
Fixes the issue mentioned in [this](https://github.com/iTwin/iTwinUI-react/issues/731#issuecomment-1273687956
) comment regarding selecting all visible rows when a filter is applied

Closes #731 