### PR TITLE
feat(Table): Ctrl + Shift click keeps previous selection & also shift clicks

### DIFF
--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -492,7 +492,6 @@ export const Table = <
         case TableActions.toggleRowSelected:
         case TableActions.toggleAllRowsSelected:
         case TableActions.toggleAllPageRowsSelected: {
-          newState.lastSelectedRowId = action.id;
           onSelectHandler(
             newState,
             instance,

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -492,6 +492,7 @@ export const Table = <
         case TableActions.toggleRowSelected:
         case TableActions.toggleAllRowsSelected:
         case TableActions.toggleAllPageRowsSelected: {
+          newState.lastSelectedRowId = action.id;
           onSelectHandler(
             newState,
             instance,
@@ -625,6 +626,7 @@ export const Table = <
           dispatch({
             type: shiftRowSelectedAction,
             id: row.id,
+            ctrlPressed: event.ctrlKey,
           });
         } else if (
           !row.isSelected &&

--- a/packages/iTwinUI-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/iTwinUI-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -121,7 +121,10 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
     endIndex = temp;
   }
 
-  const selectedRowIds: Record<string, boolean> = {};
+  console.log('shiftpressed', action.ctrlPressed);
+  const selectedRowIds: Record<string, boolean> = !!action.ctrlPressed
+    ? state.selectedRowIds
+    : {};
 
   // 1. Select all rows between start and end
   instance.flatRows

--- a/packages/iTwinUI-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/iTwinUI-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -121,7 +121,6 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
     endIndex = temp;
   }
 
-  console.log('shiftpressed', action.ctrlPressed);
   const selectedRowIds: Record<string, boolean> = !!action.ctrlPressed
     ? state.selectedRowIds
     : {};


### PR DESCRIPTION
**[CLOSED]** Moved to #888. This PR is closed as it was pointing to `main` and not `v2`. Need to point to `v2` to avoid delaying `v2` due to merge conflicts with `main`.

---

Closes #880 

* Shift click keeps previous selection when holding Ctrl when Shift clicking

**NOTE**: The related issue #879 about `lastSelectedRowId` not updating on checkbox click, will come in a separate PR, hopefully from the external contributor. After that PR, this Ctrl + Shift functionality can be completely realized.

## Screenshots

#### Steps

* Click `1.1`
* Shift click `1.2.2`
* Ctrl click `2.1` and `2.3`
* Ctrl + Shift click `1.2.4`

#### New

* Previous selection of `2.1` and `2.3` is preserved

[vokoscreenNG-2022-10-18_16-33-25.webm](https://user-images.githubusercontent.com/45748283/196538489-57f3cef7-52a9-4e5f-860a-61a334ebd274.webm)

#### Old

* Previous selection of `2.1` and `2.3` is lost

[vokoscreenNG-2022-10-18_16-41-20.webm](https://user-images.githubusercontent.com/45748283/196540551-67576324-b5a0-4eb1-b173-18e2e92e78fa.webm)

## Checklist

- [x] Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- ~[ ]~ Add component features demo in Storybook (different stories)
- ~[ ]~ Approve test images for new stories
- [x] Add screenshots of the key elements of the component
