### PR TITLE
fix(Modal): Apply z-index on dialog wrapper

### DIFF
--- a/packages/iTwinUI-react/src/core/Modal/Modal.test.tsx
+++ b/packages/iTwinUI-react/src/core/Modal/Modal.test.tsx
@@ -200,12 +200,12 @@ it('should work with portal container properly', () => {
 
   let container = document.querySelector('body > #test-id') as HTMLElement;
   expect(container).toBeTruthy();
-  expect(container.children.length).toBe(1);
+  expect(container.children.length).toBe(2);
 
   renderComponent({ modalRootId: 'test-id' });
   container = document.querySelector('body > #test-id') as HTMLElement;
   // 2 modals under the same container
-  expect(container.children.length).toBe(2);
+  expect(container.children.length).toBe(3);
 });
 
 it('should reset body overflow on closing and unmounting', () => {

--- a/packages/iTwinUI-react/src/core/utils/functions/dom.ts
+++ b/packages/iTwinUI-react/src/core/utils/functions/dom.ts
@@ -18,6 +18,7 @@ export const getContainer = (
   if (container == null && !!ownerDocument) {
     container = ownerDocument.createElement('div');
     container.setAttribute('id', containerId);
+    container.innerHTML = `<style>:where(.iui-dialog-wrapper) { z-index: 999; }</style>`; // TODO: move to css
     ownerDocument.body.appendChild(container);
   }
   return container;


### PR DESCRIPTION
In itwinui-react 1.48.0, the `Modal` component uses `iui-dialog-wrapper`, which creates a stacking context and prevents children's z-index from being applied correctly. (regression)

![](https://user-images.githubusercontent.com/9084735/197246888-7f938fc1-f69a-4402-bd6e-8a4c6a8141e1.png)

So I've added a z-index of 999 to the wrapper, which results in the correct behavior:

![](https://user-images.githubusercontent.com/9084735/197246914-deb2d2b8-6195-4531-b6dc-8ba0f1268ef1.png)


I was going to make this change in css and release another 0.X version but that would require more PRs and result in merge conflicts so I've just added a small style tag to the portal container (can be removed later). I used the `:where` selector to keep the specificity to a minimum, because some of our users want to override the z-index.