### PR TITLE
fix!: Use module imports for icons

### DIFF
--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -5,7 +5,17 @@
   "license": "MIT",
   "main": "cjs/index.js",
   "module": "esm/index.js",
-  "typings": "cjs/index.d.ts",
+  "typings": "esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./cjs/": "./cjs/",
+    "./esm/": "./esm/",
+    "./cjs/core/utils": "./cjs/core/utils/index.js",
+    "./esm/core/utils": "./esm/core/utils/index.js"
+  },
   "files": [
     "cjs",
     "esm",

--- a/packages/iTwinUI-react/src/core/Alert/Alert.tsx
+++ b/packages/iTwinUI-react/src/core/Alert/Alert.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgCloseSmall from '@itwin/itwinui-icons-react/cjs/icons/CloseSmall';
+import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 import cx from 'classnames';
 import React from 'react';
 import { CommonProps, useTheme, StatusIconMap } from '../utils';

--- a/packages/iTwinUI-react/src/core/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/iTwinUI-react/src/core/Breadcrumbs/Breadcrumbs.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { useTheme, CommonProps, useMergedRefs, useOverflow } from '../utils';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import '@itwin/itwinui-css/css/breadcrumbs.css';
 
 export type BreadcrumbsProps = {

--- a/packages/iTwinUI-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/packages/iTwinUI-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 import cx from 'classnames';
 import { Button, ButtonProps } from '../Button';
 import { DropdownMenu } from '../../DropdownMenu';
-import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
-import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
+import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
+import { SvgCaretUpSmall } from '@itwin/itwinui-icons-react';
 
 import { useTheme, useMergedRefs } from '../../utils';
 import '@itwin/itwinui-css/css/button.css';

--- a/packages/iTwinUI-react/src/core/Buttons/IdeasButton/IdeasButton.tsx
+++ b/packages/iTwinUI-react/src/core/Buttons/IdeasButton/IdeasButton.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 
-import SvgSmileyHappy from '@itwin/itwinui-icons-react/cjs/icons/SmileyHappy';
+import { SvgSmileyHappy } from '@itwin/itwinui-icons-react';
 import { useTheme } from '../../utils';
 import { Button } from '../Button';
 

--- a/packages/iTwinUI-react/src/core/Buttons/SplitButton/SplitButton.tsx
+++ b/packages/iTwinUI-react/src/core/Buttons/SplitButton/SplitButton.tsx
@@ -8,8 +8,8 @@ import { Button, ButtonProps } from '../Button';
 import { IconButton } from '../IconButton';
 import { DropdownMenu } from '../../DropdownMenu';
 import { Placement } from 'tippy.js';
-import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
-import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
+import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
+import { SvgCaretUpSmall } from '@itwin/itwinui-icons-react';
 
 import { PolymorphicForwardRefComponent, useTheme } from '../../utils';
 import '@itwin/itwinui-css/css/button.css';

--- a/packages/iTwinUI-react/src/core/Carousel/CarouselNavigation.tsx
+++ b/packages/iTwinUI-react/src/core/Carousel/CarouselNavigation.tsx
@@ -7,8 +7,8 @@ import cx from 'classnames';
 import { CarouselContext } from './CarouselContext';
 import { IconButton, IconButtonProps } from '../Buttons';
 import { CarouselDotsList } from './CarouselDotsList';
-import SvgChevronLeft from '@itwin/itwinui-icons-react/cjs/icons/ChevronLeft';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronLeft } from '@itwin/itwinui-icons-react';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 
 /** Button for switching to previous slide */
 const PreviousButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(

--- a/packages/iTwinUI-react/src/core/ColorPicker/ColorInputPanel.tsx
+++ b/packages/iTwinUI-react/src/core/ColorPicker/ColorInputPanel.tsx
@@ -8,7 +8,7 @@ import { IconButton } from '../Buttons';
 import { Input } from '../Input';
 import { ColorValue, CommonProps, InputContainer, useTheme } from '../utils';
 import { useColorPickerContext } from './ColorPickerContext';
-import SvgSwap from '@itwin/itwinui-icons-react/cjs/icons/Swap';
+import { SvgSwap } from '@itwin/itwinui-icons-react';
 import '@itwin/itwinui-css/css/color-picker.css';
 
 export type ColorInputPanelProps = {

--- a/packages/iTwinUI-react/src/core/ComboBox/ComboBoxEndIcon.tsx
+++ b/packages/iTwinUI-react/src/core/ComboBox/ComboBoxEndIcon.tsx
@@ -6,7 +6,7 @@ import cx from 'classnames';
 import React from 'react';
 import { useSafeContext, useMergedRefs } from '../utils';
 import { ComboBoxActionContext, ComboBoxRefsContext } from './helpers';
-import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
+import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
 
 type ComboBoxEndIconProps = React.ComponentPropsWithoutRef<'span'> & {
   disabled?: boolean;

--- a/packages/iTwinUI-react/src/core/DatePicker/DatePicker.tsx
+++ b/packages/iTwinUI-react/src/core/DatePicker/DatePicker.tsx
@@ -2,10 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgChevronLeft from '@itwin/itwinui-icons-react/cjs/icons/ChevronLeft';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
-import SvgChevronLeftDouble from '@itwin/itwinui-icons-react/cjs/icons/ChevronLeftDouble';
-import SvgChevronRightDouble from '@itwin/itwinui-icons-react/cjs/icons/ChevronRightDouble';
+import { SvgChevronLeft } from '@itwin/itwinui-icons-react';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
+import { SvgChevronLeftDouble } from '@itwin/itwinui-icons-react';
+import { SvgChevronRightDouble } from '@itwin/itwinui-icons-react';
 import cx from 'classnames';
 import React from 'react';
 import { useTheme } from '../utils';

--- a/packages/iTwinUI-react/src/core/Dialog/DialogTitleBar.tsx
+++ b/packages/iTwinUI-react/src/core/Dialog/DialogTitleBar.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import cx from 'classnames';
-import SvgClose from '@itwin/itwinui-icons-react/cjs/icons/Close';
+import { SvgClose } from '@itwin/itwinui-icons-react';
 import { useTheme } from '../utils';
 import { IconButton } from '../Buttons';
 import '@itwin/itwinui-css/css/dialog.css';

--- a/packages/iTwinUI-react/src/core/ErrorPage/ErrorPage.tsx
+++ b/packages/iTwinUI-react/src/core/ErrorPage/ErrorPage.tsx
@@ -2,15 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import Svg401 from '@itwin/itwinui-illustrations-react/cjs/illustrations/401';
-import Svg403 from '@itwin/itwinui-illustrations-react/cjs/illustrations/403';
-import Svg404 from '@itwin/itwinui-illustrations-react/cjs/illustrations/404';
-import Svg500 from '@itwin/itwinui-illustrations-react/cjs/illustrations/500';
-import Svg502 from '@itwin/itwinui-illustrations-react/cjs/illustrations/502';
-import Svg503 from '@itwin/itwinui-illustrations-react/cjs/illustrations/503';
-import SvgError from '@itwin/itwinui-illustrations-react/cjs/illustrations/Error';
-import SvgRedirect from '@itwin/itwinui-illustrations-react/cjs/illustrations/Redirect';
-import SvgTimedOut from '@itwin/itwinui-illustrations-react/cjs/illustrations/TimedOut';
+import { Svg401 } from '@itwin/itwinui-illustrations-react';
+import { Svg403 } from '@itwin/itwinui-illustrations-react';
+import { Svg404 } from '@itwin/itwinui-illustrations-react';
+import { Svg500 } from '@itwin/itwinui-illustrations-react';
+import { Svg502 } from '@itwin/itwinui-illustrations-react';
+import { Svg503 } from '@itwin/itwinui-illustrations-react';
+import { SvgError } from '@itwin/itwinui-illustrations-react';
+import { SvgRedirect } from '@itwin/itwinui-illustrations-react';
+import { SvgTimedOut } from '@itwin/itwinui-illustrations-react';
 import React from 'react';
 import { Button } from '../Buttons/Button';
 import { CommonProps, useTheme } from '../utils';

--- a/packages/iTwinUI-react/src/core/ExpandableBlock/ExpandableBlock.tsx
+++ b/packages/iTwinUI-react/src/core/ExpandableBlock/ExpandableBlock.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import cx from 'classnames';
 import React from 'react';
 

--- a/packages/iTwinUI-react/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/packages/iTwinUI-react/src/core/FileUpload/FileUploadTemplate.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { useTheme } from '../utils';
 import '@itwin/itwinui-css/css/file-upload.css';
-import SvgUpload from '@itwin/itwinui-icons-react/cjs/icons/Upload';
+import { SvgUpload } from '@itwin/itwinui-icons-react';
 
 export type FileUploadTemplateProps = {
   /**

--- a/packages/iTwinUI-react/src/core/Header/Header.tsx
+++ b/packages/iTwinUI-react/src/core/Header/Header.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgMoreVertical from '@itwin/itwinui-icons-react/cjs/icons/MoreVertical';
+import { SvgMoreVertical } from '@itwin/itwinui-icons-react';
 
 import cx from 'classnames';
 import React from 'react';

--- a/packages/iTwinUI-react/src/core/Header/HeaderBreadcrumbs.tsx
+++ b/packages/iTwinUI-react/src/core/Header/HeaderBreadcrumbs.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 
 import React from 'react';
 

--- a/packages/iTwinUI-react/src/core/Header/HeaderDropdownButton.tsx
+++ b/packages/iTwinUI-react/src/core/Header/HeaderDropdownButton.tsx
@@ -5,8 +5,8 @@
 import cx from 'classnames';
 import React from 'react';
 import { DropdownMenu } from '../DropdownMenu';
-import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
-import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
+import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
+import { SvgCaretUpSmall } from '@itwin/itwinui-icons-react';
 import { PolymorphicForwardRefComponent, useTheme } from '../utils';
 import { DropdownButtonProps } from '../Buttons';
 import { useMergedRefs } from '../utils';

--- a/packages/iTwinUI-react/src/core/Header/HeaderSplitButton.tsx
+++ b/packages/iTwinUI-react/src/core/Header/HeaderSplitButton.tsx
@@ -5,8 +5,8 @@
 import cx from 'classnames';
 import React from 'react';
 import { DropdownMenu } from '../DropdownMenu';
-import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
-import SvgCaretUpSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretUpSmall';
+import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
+import { SvgCaretUpSmall } from '@itwin/itwinui-icons-react';
 
 import { PolymorphicForwardRefComponent, useTheme } from '../utils';
 import { SplitButtonProps } from '../Buttons';

--- a/packages/iTwinUI-react/src/core/InformationPanel/InformationPanelHeader.tsx
+++ b/packages/iTwinUI-react/src/core/InformationPanel/InformationPanelHeader.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { IconButton } from '../Buttons';
-import SvgCloseSmall from '@itwin/itwinui-icons-react/cjs/icons/CloseSmall';
+import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 import { CommonProps, useTheme } from '../utils';
 import '@itwin/itwinui-css/css/information-panel.css';
 

--- a/packages/iTwinUI-react/src/core/Menu/MenuItem.tsx
+++ b/packages/iTwinUI-react/src/core/Menu/MenuItem.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import cx from 'classnames';
 import { CommonProps, useTheme, Popover, useMergedRefs } from '../utils';
 import '@itwin/itwinui-css/css/menu.css';
-import SvgCaretRightSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretRightSmall';
+import { SvgCaretRightSmall } from '@itwin/itwinui-icons-react';
 import { Menu } from './Menu';
 
 /**

--- a/packages/iTwinUI-react/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
+++ b/packages/iTwinUI-react/src/core/ProgressIndicators/ProgressRadial/ProgressRadial.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import Positive from '@itwin/itwinui-icons-react/cjs/icons/CheckmarkSmall';
-import Negative from '@itwin/itwinui-icons-react/cjs/icons/ImportantSmall';
+import { SvgStatusSuccess } from '@itwin/itwinui-icons-react';
+import { SvgStatusError } from '@itwin/itwinui-icons-react';
 import cx from 'classnames';
 import React from 'react';
 import { CommonProps, useTheme } from '../../utils';
@@ -66,8 +66,8 @@ export const ProgressRadial = (props: ProgressRadialProps) => {
   useTheme();
 
   const statusMap = {
-    negative: <Negative aria-hidden />,
-    positive: <Positive aria-hidden />,
+    negative: <SvgStatusError aria-hidden />,
+    positive: <SvgStatusSuccess aria-hidden />,
   };
 
   const fillStyle: React.CSSProperties = {

--- a/packages/iTwinUI-react/src/core/Select/Select.tsx
+++ b/packages/iTwinUI-react/src/core/Select/Select.tsx
@@ -14,7 +14,7 @@ import {
   useOverflow,
 } from '../utils';
 import '@itwin/itwinui-css/css/select.css';
-import SvgCaretDownSmall from '@itwin/itwinui-icons-react/cjs/icons/CaretDownSmall';
+import { SvgCaretDownSmall } from '@itwin/itwinui-icons-react';
 import SelectTag from './SelectTag';
 
 const isMultipleEnabled = <T,>(

--- a/packages/iTwinUI-react/src/core/SideNavigation/SideNavigation.tsx
+++ b/packages/iTwinUI-react/src/core/SideNavigation/SideNavigation.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { useTheme, CommonProps, WithCSSTransition } from '../utils';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import { IconButton } from '../Buttons';
 import { Tooltip } from '../Tooltip';
 import '@itwin/itwinui-css/css/side-navigation.css';

--- a/packages/iTwinUI-react/src/core/Table/SubRowExpander.tsx
+++ b/packages/iTwinUI-react/src/core/Table/SubRowExpander.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import { Cell, CellProps } from 'react-table';
 import { IconButton } from '../Buttons';
 

--- a/packages/iTwinUI-react/src/core/Table/Table.tsx
+++ b/packages/iTwinUI-react/src/core/Table/Table.tsx
@@ -27,8 +27,8 @@ import {
 import { ProgressRadial } from '../ProgressIndicators';
 import { useTheme, CommonProps, useResizeObserver } from '../utils';
 import '@itwin/itwinui-css/css/table.css';
-import SvgSortDown from '@itwin/itwinui-icons-react/cjs/icons/SortDown';
-import SvgSortUp from '@itwin/itwinui-icons-react/cjs/icons/SortUp';
+import { SvgSortDown } from '@itwin/itwinui-icons-react';
+import { SvgSortUp } from '@itwin/itwinui-icons-react';
 import { getCellStyle, getStickyStyle } from './utils';
 import { TableRowMemoized } from './TableRowMemoized';
 import { FilterToggle, TableFilterValue } from './filters';

--- a/packages/iTwinUI-react/src/core/Table/TablePaginator.tsx
+++ b/packages/iTwinUI-react/src/core/Table/TablePaginator.tsx
@@ -5,8 +5,8 @@
 import React from 'react';
 import cx from 'classnames';
 import '@itwin/itwinui-css/css/table.css';
-import SvgChevronLeft from '@itwin/itwinui-icons-react/cjs/icons/ChevronLeft';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronLeft } from '@itwin/itwinui-icons-react';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import { IconButton, Button, DropdownButton } from '../Buttons';
 import { ProgressRadial } from '../ProgressIndicators';
 import { MenuItem } from '../Menu';

--- a/packages/iTwinUI-react/src/core/Table/columns/actionColumn.tsx
+++ b/packages/iTwinUI-react/src/core/Table/columns/actionColumn.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { HeaderProps } from 'react-table';
 import { Checkbox } from '../../Checkbox';
-import SvgColumnManager from '@itwin/itwinui-icons-react/cjs/icons/ColumnManager';
+import { SvgColumnManager } from '@itwin/itwinui-icons-react';
 import { DropdownMenu, DropdownMenuProps } from '../../DropdownMenu';
 import { IconButton } from '../../Buttons/IconButton';
 import { MenuItem } from '../../Menu';

--- a/packages/iTwinUI-react/src/core/Table/columns/expanderColumn.tsx
+++ b/packages/iTwinUI-react/src/core/Table/columns/expanderColumn.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import { CellProps, CellRendererProps, Row } from 'react-table';
 import { IconButton } from '../../Buttons';
 import { DefaultCell } from '../cells';

--- a/packages/iTwinUI-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import SvgCalendar from '@itwin/itwinui-icons-react/cjs/icons/Calendar';
+import { SvgCalendar } from '@itwin/itwinui-icons-react';
 import { Popover } from '../../../utils';
 import { LabeledInput, LabeledInputProps } from '../../../LabeledInput';
 import { DatePicker } from '../../../DatePicker';

--- a/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
+++ b/packages/iTwinUI-react/src/core/Table/filters/FilterToggle.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgFilterHollow from '@itwin/itwinui-icons-react/cjs/icons/FilterHollow';
-import SvgFilter from '@itwin/itwinui-icons-react/cjs/icons/Filter';
+import { SvgFilterHollow } from '@itwin/itwinui-icons-react';
+import { SvgFilter } from '@itwin/itwinui-icons-react';
 import React from 'react';
 import cx from 'classnames';
 import { HeaderGroup } from 'react-table';

--- a/packages/iTwinUI-react/src/core/Tag/Tag.tsx
+++ b/packages/iTwinUI-react/src/core/Tag/Tag.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from 'classnames';
 import React from 'react';
-import SvgCloseSmall from '@itwin/itwinui-icons-react/cjs/icons/CloseSmall';
+import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 import { useTheme, CommonProps } from '../utils';
 import '@itwin/itwinui-css/css/tag.css';
 import { IconButton } from '../Buttons';

--- a/packages/iTwinUI-react/src/core/Tile/Tile.tsx
+++ b/packages/iTwinUI-react/src/core/Tile/Tile.tsx
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import cx from 'classnames';
-import SvgCheckmark from '@itwin/itwinui-icons-react/cjs/icons/Checkmark';
-import SvgMore from '@itwin/itwinui-icons-react/cjs/icons/More';
-import SvgNew from '@itwin/itwinui-icons-react/cjs/icons/New';
+import { SvgCheckmark } from '@itwin/itwinui-icons-react';
+import { SvgMore } from '@itwin/itwinui-icons-react';
+import { SvgNew } from '@itwin/itwinui-icons-react';
 import { useTheme } from '../utils';
 import '@itwin/itwinui-css/css/tile.css';
 import { DropdownMenu } from '../DropdownMenu';

--- a/packages/iTwinUI-react/src/core/Toast/Toast.tsx
+++ b/packages/iTwinUI-react/src/core/Toast/Toast.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import { Transition } from 'react-transition-group';
-import SvgCloseSmall from '@itwin/itwinui-icons-react/cjs/icons/CloseSmall';
+import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 import cx from 'classnames';
 import { useTheme, getWindow, StatusIconMap, CommonProps } from '../utils';
 import '@itwin/itwinui-css/css/toast.css';

--- a/packages/iTwinUI-react/src/core/Tree/TreeNodeExpander.tsx
+++ b/packages/iTwinUI-react/src/core/Tree/TreeNodeExpander.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import cx from 'classnames';
-import SvgChevronRight from '@itwin/itwinui-icons-react/cjs/icons/ChevronRight';
+import { SvgChevronRight } from '@itwin/itwinui-icons-react';
 import { IconButton, IconButtonProps } from '../Buttons/IconButton';
 import '@itwin/itwinui-css/css/tree.css';
 

--- a/packages/iTwinUI-react/src/core/utils/components/icons.tsx
+++ b/packages/iTwinUI-react/src/core/utils/components/icons.tsx
@@ -2,10 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import SvgInfoCircular from '@itwin/itwinui-icons-react/cjs/icons/InfoCircular';
-import SvgStatusError from '@itwin/itwinui-icons-react/cjs/icons/StatusError';
-import SvgStatusSuccess from '@itwin/itwinui-icons-react/cjs/icons/StatusSuccess';
-import SvgStatusWarning from '@itwin/itwinui-icons-react/cjs/icons/StatusWarning';
+import { SvgInfoCircular } from '@itwin/itwinui-icons-react';
+import { SvgStatusError } from '@itwin/itwinui-icons-react';
+import { SvgStatusSuccess } from '@itwin/itwinui-icons-react';
+import { SvgStatusWarning } from '@itwin/itwinui-icons-react';
 import React from 'react';
 import { CommonProps } from '../props';
 


### PR DESCRIPTION
Build tested working fine (including tree shaking) with:
- Vite 3 (uses esbuild/rollup)
- Next.js 12 (uses webpack 5)
- CRA 5 (uses webpack 5)
- CRA 4 (uses webpack 4)

Astro (which uses vite SSR) still has problems building, even when i added export maps to icon packages. Investigating.