### PR TITLE
docs: Rename Wizard to Stepper

### DIFF
--- a/apps/website/src/examples/Stepper.main.tsx
+++ b/apps/website/src/examples/Stepper.main.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Button, Wizard } from '@itwin/itwinui-react';
+import { Button, Stepper } from '@itwin/itwinui-react';
 
 export default () => {
   const [currentStep, setCurrentStep] = React.useState(2);
@@ -28,7 +28,7 @@ export default () => {
 
   return (
     <div style={{ width: '90%' }}>
-      <Wizard currentStep={currentStep} steps={steps} onStepClick={onStepClick} />
+      <Stepper currentStep={currentStep} steps={steps} onStepClick={onStepClick} />
       <div style={{ display: 'flex', gap: '8px', justifyContent: 'center', marginTop: '24px' }}>
         <Button size='small' onClick={previousStepHandler}>
           Previous

--- a/apps/website/src/examples/index.tsx
+++ b/apps/website/src/examples/index.tsx
@@ -59,4 +59,4 @@ export { default as TileMainExample } from './Tile.main';
 export { default as TooltipMainExample } from './Tooltip.main';
 export { default as TooltipStaticExample } from './Tooltip.static';
 export { default as TreeMainExample } from './Tree.main';
-export { default as WizardMainExample } from './Wizard.main';
+export { default as WizardMainExample } from './Stepper.main';

--- a/apps/website/src/examples/index.tsx
+++ b/apps/website/src/examples/index.tsx
@@ -59,4 +59,4 @@ export { default as TileMainExample } from './Tile.main';
 export { default as TooltipMainExample } from './Tooltip.main';
 export { default as TooltipStaticExample } from './Tooltip.static';
 export { default as TreeMainExample } from './Tree.main';
-export { default as WizardMainExample } from './Stepper.main';
+export { default as StepperMainExample } from './Stepper.main';

--- a/apps/website/src/pages/docs/stepper.mdx
+++ b/apps/website/src/pages/docs/stepper.mdx
@@ -2,7 +2,7 @@
 title: Stepper
 description: Keep the user informed on their progress by dividing content into logical steps.
 layout: ./_layout.astro
-propsPath: '@itwin/itwinui-react/esm/core/Stepper/Stepper.d.ts'
+propsPath: '@itwin/itwinui-react/src/core/Stepper/Stepper.tsx'
 exampleCodeFile1: Stepper.main.tsx
 group: core
 ---
@@ -14,7 +14,7 @@ import LiveExample from '~/components/LiveExample.astro';
 
 <LiveExample src={frontmatter.exampleCodeFile1} />
 
-In defined, multi-step user interactions, it is useful to inform the user of the number of steps involved in the process, and the current step within that sequence. A UI 'Wizard' guides the user through the steps and provides some interaction to return to previous steps. A standard example of a wizard would be an e-Commerce checkout process, but there are many others where the user must perform sequential steps.
+In defined, multi-step user interactions, it is useful to inform the user of the number of steps involved in the process, and the current step within that sequence. A UI 'Stepper' guides the user through the steps and provides some interaction to return to previous steps. A standard example of a Stepper would be an e-Commerce checkout process, but there are many others where the user must perform sequential steps.
 
 ## Props
 

--- a/apps/website/src/pages/docs/stepper.mdx
+++ b/apps/website/src/pages/docs/stepper.mdx
@@ -1,9 +1,9 @@
 ---
-title: Wizard
+title: Stepper
 description: Keep the user informed on their progress by dividing content into logical steps.
 layout: ./_layout.astro
-propsPath: '@itwin/itwinui-react/esm/core/Wizard/Wizard.d.ts'
-exampleCodeFile1: Wizard.main.tsx
+propsPath: '@itwin/itwinui-react/esm/core/Stepper/Stepper.d.ts'
+exampleCodeFile1: Stepper.main.tsx
 group: core
 ---
 

--- a/packages/iTwinUI-react/src/core/Stepper/Stepper.tsx
+++ b/packages/iTwinUI-react/src/core/Stepper/Stepper.tsx
@@ -51,8 +51,8 @@ const defaultStepperLocalization: StepperLocalization = {
     `Step ${currentStep} of ${totalSteps}:`,
 };
 
-export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
-  (props, ref) => {
+export const Stepper = React.forwardRef(
+  (props: StepperProps, ref: React.Ref<HTMLDivElement>) => {
     const {
       currentStep,
       steps,


### PR DESCRIPTION
Leftover from #905. Needed for build to pass.

Sandbox will currently fail but build will pass. Should be fixed in #916.