### PR TITLE
fix(Table): Remove generic from `columns` type

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview",
     "clean": "rimraf .turbo && rimraf node_modules && rimraf dist"
   },

--- a/packages/iTwinUI-react/src/types/react-table-config.ts
+++ b/packages/iTwinUI-react/src/types/react-table-config.ts
@@ -82,7 +82,7 @@ declare module 'react-table' {
 
   // take this file as-is, or comment out the sections that don't apply to your plugin configuration
   export interface TableOptions<D extends object = {}>
-    extends Omit<UseTableOptions<D>, 'data'>,
+    extends Omit<UseTableOptions<D>, 'data' | 'columns'>,
       UseRowSelectOptions<D>,
       UseExpandedOptions<D>,
       UseFiltersOptions<D>,

--- a/packages/iTwinUI-react/src/types/react-table-config.ts
+++ b/packages/iTwinUI-react/src/types/react-table-config.ts
@@ -96,8 +96,7 @@ declare module 'react-table' {
     /**
      * List of columns.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    columns: Array<Column<any>>;
+    columns: Array<Column<any>>; // eslint-disable-line @typescript-eslint/no-explicit-any
     /**
      * Table data list.
      * Must be memoized.

--- a/packages/iTwinUI-react/src/types/react-table-config.ts
+++ b/packages/iTwinUI-react/src/types/react-table-config.ts
@@ -94,6 +94,11 @@ declare module 'react-table' {
       // UseRowStateOptions<D>,
       UseSortByOptions<D> {
     /**
+     * List of columns.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    columns: Array<Column<any>>;
+    /**
      * Table data list.
      * Must be memoized.
      *


### PR DESCRIPTION
Overriding react-table columns with a more narrow version and passing `any` to the generic. This fixes build errors. Typing can be improved later.