### PR TITLE
chore: Fix eslint blocking commits when changing .js files

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -45,8 +45,10 @@
   "lint-staged": {
     "*.{tsx,ts,jsx,js}": [
       "prettier --write",
-      "eslint --max-warnings=0 --fix",
       "node ../../packages/configs/copyrightLinter.js --fix"
+    ],
+    "*.{tsx,ts}": [
+      "eslint --max-warnings=0 --fix"
     ]
   },
   "prettier": "configs/prettier-config",

--- a/packages/iTwinUI-react/package.json
+++ b/packages/iTwinUI-react/package.json
@@ -108,8 +108,10 @@
   "lint-staged": {
     "*.{tsx,ts,jsx,js}": [
       "prettier --write",
-      "eslint --max-warnings=0 --fix",
       "node ../configs/copyrightLinter.js --fix"
+    ],
+    "*.{tsx,ts}": [
+      "eslint --max-warnings=0 --fix"
     ]
   },
   "prettier": "configs/prettier-config",


### PR DESCRIPTION
No longer running `eslint` on `js` files in pre-commit hook.

Fixes #970.