### PR TITLE
fix(ThemeProvider): Exclude `ownerDocument` from `themeOptions` if children passed

### DIFF
--- a/packages/iTwinUI-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/iTwinUI-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -10,13 +10,31 @@ import type {
   PolymorphicForwardRefComponent,
   ThemeOptions,
   ThemeType,
-  UseThemeProps,
 } from '../utils';
 import '@itwin/itwinui-css/css/global.css';
 import '@itwin/itwinui-variables/index.css';
 
 export type ThemeProviderProps<T extends React.ElementType = 'div'> =
-  PolymorphicComponentProps<T, UseThemeProps>;
+  PolymorphicComponentProps<T, ThemeProviderOwnProps>;
+
+type ThemeProviderOwnProps = {
+  /**
+   * Theme to be applied. Can be 'light' or 'dark' or 'os'.
+   *
+   * Note that 'os' will respect the system preference on client but will fallback to 'light'
+   * in SSR environments because it is not possible detect system preference on the server.
+   * This can cause a flash of incorrect theme on first render.
+   *
+   * @default 'light'
+   */
+  theme?: ThemeType;
+} & (
+  | {
+      themeOptions?: Pick<ThemeOptions, 'highContrast'>;
+      children: Required<React.ReactNode>;
+    }
+  | { themeOptions?: ThemeOptions; children?: undefined }
+);
 
 /**
  * This component provides global styles and applies theme to the entire tree
@@ -59,9 +77,14 @@ export const ThemeProvider = React.forwardRef((props, ref) => {
   const shouldApplyDark = theme === 'dark' || (theme === 'os' && prefersDark);
   const shouldApplyHC = themeOptions?.highContrast ?? prefersHighContrast;
 
+  const contextValue = React.useMemo(
+    () => ({ theme, themeOptions, rootRef }),
+    [theme, themeOptions],
+  );
+
   // only provide context if wrapped around children
   return hasChildren ? (
-    <ThemeContext.Provider value={{ theme, themeOptions, rootRef }}>
+    <ThemeContext.Provider value={contextValue}>
       <Element
         className={cx('iui-root', className)}
         data-iui-theme={shouldApplyDark ? 'dark' : 'light'}
@@ -79,7 +102,7 @@ export const ThemeProvider = React.forwardRef((props, ref) => {
       themeOptions={themeOptions ?? parentContext?.themeOptions}
     />
   );
-}) as PolymorphicForwardRefComponent<'div', UseThemeProps>;
+}) as PolymorphicForwardRefComponent<'div', ThemeProviderOwnProps>;
 
 export default ThemeProvider;
 
@@ -92,7 +115,7 @@ export const ThemeContext = React.createContext<
   | undefined
 >(undefined);
 
-const ThemeLogicWrapper = ({ theme, themeOptions }: UseThemeProps) => {
+const ThemeLogicWrapper = ({ theme, themeOptions }: ThemeProviderOwnProps) => {
   useTheme(theme, themeOptions);
   return <></>;
 };

--- a/packages/iTwinUI-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/iTwinUI-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -77,14 +77,9 @@ export const ThemeProvider = React.forwardRef((props, ref) => {
   const shouldApplyDark = theme === 'dark' || (theme === 'os' && prefersDark);
   const shouldApplyHC = themeOptions?.highContrast ?? prefersHighContrast;
 
-  const contextValue = React.useMemo(
-    () => ({ theme, themeOptions, rootRef }),
-    [theme, themeOptions],
-  );
-
   // only provide context if wrapped around children
   return hasChildren ? (
-    <ThemeContext.Provider value={contextValue}>
+    <ThemeContext.Provider value={{ theme, themeOptions, rootRef }}>
       <Element
         className={cx('iui-root', className)}
         data-iui-theme={shouldApplyDark ? 'dark' : 'light'}


### PR DESCRIPTION
Instead of relying on `UseThemeProps`, `ThemeProvider` now defines its own props and uses conditional typing to exclude `ownerDocument` from `themeOptions` if children is passed, and keep `ownerDocument` if children not passed (for backwards compatibility). This change is intended to prevent accidentally passing `ownerDocument`. Would be nice to release it as a patch of 2.0 rather than in 2.1 so that users have a smaller window to make this mistake.

Also, since we are defining a new type, I used the opportunity to write a better jsdoc for the `theme` prop, warning about SSR behavior.
