### PR TITLE
fix: Use `import type` instead of `import { type }`

### DIFF
--- a/packages/iTwinUI-react/src/core/utils/icons/StatusIconMap.tsx
+++ b/packages/iTwinUI-react/src/core/utils/icons/StatusIconMap.tsx
@@ -7,7 +7,7 @@ import { SvgInfoCircular } from './SvgInfoCircular';
 import { SvgStatusError } from './SvgStatusError';
 import { SvgStatusSuccess } from './SvgStatusSuccess';
 import { SvgStatusWarning } from './SvgStatusWarning';
-import { type CommonProps } from '../props';
+import type { CommonProps } from '../props';
 
 export const StatusIconMap = {
   negative: (args?: CommonProps) => <SvgStatusError aria-hidden {...args} />,


### PR DESCRIPTION
`import { type X }` was added in [typescript 4.5](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names). users who are on older versions of typescript were getting build errors, so i've replaced it with `import type { X }` which is more widely supported.

i did a global regex search for `import(.*)type` and didn't find any other instances of `{ type X }` imports in our components. there are a few in other workspaces but those are fine to leave.